### PR TITLE
Manuscripts 256, 29

### DIFF
--- a/data/3_drafts/ClaireChen/256.xml
+++ b/data/3_drafts/ClaireChen/256.xml
@@ -1,0 +1,478 @@
+<?xml version="1.0" encoding="utf-8"?>
+<?oxygen RNGSchema="https://raw.githubusercontent.com/wlpotter/syriaca-wright-catalog/master/schemas/enrich-syriaca.rnc" type="compact"?>
+<?xml-stylesheet type="text/css" href="https://raw.githubusercontent.com/srophe/wright-catalogue/master/parameters/wright-mss.css"?>
+<TEI xml:lang="en" xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader xmlns="http://www.tei-c.org/ns/1.0">
+    <fileDesc>
+      <titleStmt>
+        <title>Content pending</title>
+      </titleStmt>
+      <editionStmt>
+        <p>Content pending</p>
+      </editionStmt>
+      <publicationStmt>
+        <p>Content pending</p>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <idno type="URI">256</idno>
+            <altIdentifier>
+              <idno type="BL-Shelfmark">Add. 14, 529.</idno>
+            </altIdentifier>
+          </msIdentifier>
+          <msContents>
+            <summary/>
+            <textLang mainLang="syr"/>
+            <msItem>
+              <locus to="" from="1b"/>
+              <author ref="">The Synodicon of Damasus, bishop of Rome</author>
+              <title ref="" xml:lang="en">The Synodicon of Damasus, bishop of Rome, against various
+                heresies</title>
+              <rubric xml:lang="syr">ܣܘܢܗܕܝܩܢ ܕܕܡܣܘܣ ܐܦܣܩܦܐ ܕܪܗܘܡܐ̣. ܠܘܩܒܠ ܗܪ̈ܣܝܣ ܡܫ̈ܚܠܦܬܐ</rubric>
+              <incipit xml:lang="syr">ܬܘܕܝܬܐ ܕܗܝܡܢܘܬܐ ܩܬܠܝܩܐ̇. ܗ̇ܝ ܕܫܕܪ ܕܡܣܘܣ ܐܦܣܩܦܐ̇. ܠܘܬ ܦܠܘܝܢܐ
+                ܐܦܣܩܘܦܐ ܗ̇ܘ ܕܗܘ̣ܐ ܒܬܣܠܘܢܝܩܐ. ܡܛܠ ܕܡܢ ܒܬܪ ܣܘܢܗܕܘܣ ܕܐܬ݂ܟ݁ܢܫܬ ܒܢܝܩܝܐ̣. ܢܒܥ̣ܬ ܛܥܝܘܬܐ
+                ܗܕܐ̇. ܐܝܟ ܕܢܡܪܚܘܢ ܐܢܫܝܢ ܒܦܘܡܐ ܦܩܪܐ ܠܡܐܡܪ̈. ܕܒܝܕ ܒܪܐ ܗܘ̣ܐ ܪܘܚܐ ܕܩܘܕܫܐ. ܏ܘܫ. </incipit>
+              <quote xml:lang="syr">
+                <locus from="" to=""/>
+              </quote>
+              <explicit xml:lang="syr">
+                <locus to="" from=""/>
+              </explicit>
+              <finalRubric xml:lang="syr">
+                <locus to="" from=""/>
+              </finalRubric>
+              <note>This is the "<ref>Confessio Fidei Catholicae</ref>," contained in the letter of
+                  <persName>Damasus</persName> to <persName>Paulinus, bishop of Antioch</persName>
+              </note>
+              <note>see <bibl>Gallandii Biblioth. Vett. Patrum, t. vi., p. 325 seqq., especially pp.
+                  328—330</bibl></note>
+              <note>See <bibl>Add. 14,533, fol. 125 a</bibl>.</note>
+            </msItem>
+            <msItem>
+              <locus to="" from="3a"/>
+              <author ref=""/>
+              <title ref="" xml:lang="en">Judgments of the Council of Ephesus <note>viz. against
+                <persName ref="http://syriaca.org/person/655">Nestorius</persName></note></title>
+              <rubric xml:lang="syr">ܟܪ̈ܣܝܣ ܡܢ ܣܘܢܗܕܘܣ ܕܐܦܣܘܣ</rubric>
+              <incipit xml:lang="syr"/>
+              <quote xml:lang="syr">
+                <locus from="" to=""/>
+              </quote>
+              <explicit xml:lang="syr">
+                <locus to="" from=""/>
+              </explicit>
+              <finalRubric xml:lang="syr">
+                <locus to="" from=""/>
+              </finalRubric>
+              <note>The contents coincide with <bibl>Labbe, Sacrosancta Concilia, t. iv., coll.
+                  1051—63</bibl>, except that the testimonies of <persName>Atticus</persName> and
+                <persName ref="http://syriaca.org/person/2784">Amphilochius</persName> (<bibl>coll. 1062—63</bibl>) are omitted, and a
+                long extract from <persName ref="http://syriaca.org/person/430">Cyril of Alexandria</persName> is substituted. The
+                Fathers cited are— <p><persName ref="http://syriaca.org/person/1413">Peter of Alexandria</persName>: <quote xml:lang="syr">ܡܢ ܟܬܒܐ ܕܥܠ ܐܠܗܘܬܐ</quote>,
+                  <locus>fol. 3 a</locus>.</p>
+                <p><persName>Athanasius</persName>: <quote xml:lang="syr">ܡܢ ܟܬܒܐ ܕܠܘܩܒܠ ܐܪ̈ܝܢܘ܆ ܡܢ ܡܐܡܪܐ ܕܬܠܬܐ</quote>, <locus>fol. 3 b</locus>;
+                  <quote xml:lang="syr">ܡܢ ܐܓܪܬܐ ܕܠܘܬ ܐܦܝܩܛܛܘܣ</quote>, <locus>fol, 4 a</locus>.</p>
+                <p><persName ref="http://syriaca.org/person/2163">Julius of Rome</persName>: <quote xml:lang="syr">ܡܢ ܐܓܪܬܐ ܕܠܘܬ ܦܪܘܣܕܝܩܣ</quote>, <locus>fol. 4 b</locus>.</p>
+                <p><persName>Felix of Rome</persName>: <quote xml:lang="syr">ܡܢ ܐܓܪܬܐ ܕܠܘܬ ܡܟܣܝܡܘܣ</quote>, <locus>fol. 4 b</locus>.</p>
+                <p><persName ref="http://syriaca.org/person/2507">Theophilus of Alexandria</persName>: from the fifth and sixth festal
+                  letters, <quote xml:lang="syr">ܐܓܪ̈ܬܐ ܕܥܐܕܐ</quote>, <locus>fol. 5 a</locus>.</p>
+                <p><persName>Cyprian</persName>: <quote xml:lang="syr">ܡܢ ܦܘܫܩܐ ܕܥܠ ܙܕܩܬܐ</quote>, <locus>fol. 5 b</locus>.</p>
+                <p><persName ref="http://syriaca.org/person/963">Ambrose of Milan</persName>: <locus>foll. 5 b, 6 a</locus>.</p>
+                <p><persName ref="http://syriaca.org/person/511">Gregory Nazianzen</persName>: <locus>fol. 6 a</locus>.</p>
+                <p><persName>Basil</persName>: <locus>fol. 7 a</locus>.</p>
+                <p><persName>Gregory Nyssen</persName>: <locus>fol. 7 a</locus>.</p>
+                <p><persName ref="http://syriaca.org/person/430">Cyril of Alexandria</persName>: <quote xml:lang="syr">ܡܢ ܐܓܪܬܐ ܕܠܘܬ ܕܝܪ̈ܝܐ</quote>, <locus>foll. 7 b</locus>,
+                  seqq.</p>
+              </note>
+            </msItem>
+            <msItem>
+              <locus to="" from="10a"/>
+              <author ref=""/>
+              <title ref="" xml:lang="en">Select Judgments of the holy Fathers against the heresies
+                of <persName ref="http://syriaca.org/person/579">Julian of Halicarnassus</persName></title>
+              <rubric xml:lang="syr">ܟܪ̈ܣܝܣ ܡ̈ܓܒܝܬܐ ܕܐܒ̈ܗܬܐ ܩ̈ܕܝܫܐ ܠܘܩܒܠ ܗܪ̈ܣܝܣ ܕܝܘܠܝܢܐ
+                ܕܐܠܝܩܪܢܣܘܣ.</rubric>
+              <incipit xml:lang="syr"/>
+              <quote xml:lang="syr">
+                <locus from="" to=""/>
+              </quote>
+              <explicit xml:lang="syr">
+                <locus to="" from=""/>
+              </explicit>
+              <finalRubric xml:lang="syr">
+                <locus to="" from=""/>
+              </finalRubric>
+              <note>The Fathers cited are— <p><persName>Ephraim</persName>: <quote xml:lang="syr">ܡܢ
+                    ܡܐܡܪܐ ܕܒܪܫܝܬ. ܕܐܝܬܘܗܝ ܪܫܗ ܡܫܒܚ ܐܒܐ ܡܫܒܚܐ</quote>, <locus>fol. 10 a</locus>.</p>
+                <p><persName ref="http://syriaca.org/person/33">Isaac of Antioch</persName>: <quote xml:lang="syr">ܡܢ ܡܐܡܪܐ ܕܗܝܡܢܘܬܐ.
+                    ܕܐܝܬܘܗܝ ܪܫܗ̣. ܒܗܝܡܢܘܬܐ ܩܐܡ ܐܢܐ ܕܐܨܘܪܗ̇ ܠܗܝܡܢܘܬܐ</quote>, <locus>fol. 11
+                    a</locus>.</p>
+                <p><persName>Jacob of Batnae</persName>: <quote xml:lang="syr">ܡܢ ܡܐܡܪܐ ܕܠܘܩܒܠ
+                    ܐܪܝܘܣ</quote>, <locus>fol. 11 b</locus>; <quote xml:lang="syr">ܡܢ ܡܐܡܪܐ ܕܥܠ
+                    ܥܙܙܐܝܠ</quote>, <locus>fol. 11 b</locus>; <quote xml:lang="syr">ܡܢ ܡܐܡܪܐ
+                    ܕܗܝܡܢܘܬܐ</quote>, <locus>fol.11 b</locus>; <quote xml:lang="syr">ܡܢ ܡܐܡܪܐ
+                    ܕܗܝܡܢܘܬܐ ܕܐܝܬܘܗܝ ܪܫܗ̣. ܒܪܐ ܕܒܡܘܬܗ ܐܚܝ ܡ̈ܝܬܐ ܘܙ̇ܕܩ ܚܝ̈ܐ.</quote> , <locus>fol. 12
+                    a</locus>; <quote xml:lang="syr">ܡܢ ܡܐܡܪܐ ܕܗܝܡܢܘܬܐ</quote>, <locus>fol, 12
+                    a</locus>; <quote xml:lang="syr">ܡܢ ܡܐܡܪܐ ܕܥܠ ܗ̇ܝ ܕܐܢ ܡܝܘܬܐ ܘܠܐ ܡܝܘܬܐ ܐܬ݂ܒܪܝ
+                    ܐܕܡ</quote>, <locus>fol.12 b</locus>. <quote xml:lang="syr">ܡܢ ܡܐܡܪܐ
+                    ܕܗܝܡܢܘܬܐ</quote> ,<locus>fol.13 a</locus>.</p>
+                <p><persName ref="http://syriaca.org/person/44">Philoxenus of Mabūg</persName>:
+                    <quote xml:lang="syr">ܡܢ ܡܡܠܠܐ ܕܘ̇ܠܐ ܕܢܬܬܣܝܡ ܩܕܡ ܦܘܫܩܐ ܕܪ̈ܫܐ. ܐܝܟ ܕܠܘܩܒܠ
+                    ܬܐܕܘܪܘܣ</quote>, <locus>fol. 13 a</locus>; <quote xml:lang="syr">ܡܢ ܦܢܩܝܬܐ
+                    ܕܠܘܩܒܠ ܚܒܝܒ</quote> (<bibl>see Assemani, Bibl. Or., t. ii., p. 45, no.
+                  18</bibl>), <locus>fol. 14 b</locus>; <quote xml:lang="syr">ܡܢ ܐܓܪܬܐ ܕܠܘܬ ܕܝܪ̈ܝܐ
+                    ܕܬܠܥܕܐ</quote>, <locus>fol. 14 b</locus>; <quote xml:lang="syr">ܡܢ ܡܐܡܪܐ ܕܫܒܥܐ
+                    ܕܠܘܩܒܠ ܚܒܝܒ</quote>, <locus>fol. 15 a</locus>; <quote xml:lang="syr">ܡܢ ܡܐܡܪܐ
+                    ܩܕܡܝܐ ܕܥܠ ܡܬܒܪܢܫܢܘܬܐ</quote>, <locus>fol. 15 b</locus>; <quote xml:lang="syr">ܡܢ
+                    ܐܓܪܬܐ ܕܠܘܬ ܐܘܪܢ ܣܟܠܣܬܝܩܐ</quote>, <locus>fol. 16 a</locus>.</p>
+                <p><persName>Severianus of Gabala</persName>: <quote xml:lang="syr">ܕܣܘܪܝܢܣ ܐܦܣܩܦܐ
+                    ܕܓܒܠܐ</quote>, <locus>fol. 17 a</locus>.</p>
+                <p><persName ref="http://syriaca.org/person/2507">Theophilus of
+                    Alexandria</persName>: <quote xml:lang="syr">ܡܢ ܡܐܡܪܐ ܕܥܒ̣ܕ ܠܘܬ ܐܢܫ</quote>,
+                    <locus>fol. 17 b</locus>; <quote xml:lang="syr">ܡܢ ܐܓܪܬܐ ܕܥܣܪܝܢ ܘܬܪ̈ܬܝܢ
+                    ܕܥܐܕܐ.</quote>, <locus>fol. 17 b</locus>.</p>
+                <p><persName ref="http://syriaca.org/person/2786">Atticus of
+                    Constantinople</persName>: <locus>fol. 18 a</locus>.</p>
+                <p><persName ref="http://syriaca.org/person/430">Cyril of Alexandria</persName>:
+                    <quote xml:lang="syr">ܡܢ ܐܓܪܬܐ ܕܠܘܬ ܐܩܩܝܣ</quote>, <locus>fol. 18 b</locus>;
+                    <quote xml:lang="syr">ܡܢ ܟܬܒܐ ܕܠܘܬ ܡ̈ܠܟܬܐ. ܕܐܠܗܐ ܗܘ ܡܫܝ̣ܚܐ</quote>, <locus>fol.
+                    18 b</locus>; <quote xml:lang="syr">ܡܢ ܡܐܡܪܐ ܕܥܠ ܡܬܒܪܢܫܘܬܐ</quote>, <locus>fol.
+                    20 a</locus>; <quote xml:lang="syr">ܕܚܕ ܗܘ ܡܫܝܚܐ</quote>, <locus>fol. 20
+                    a</locus>; <quote xml:lang="syr">ܡܢ ܡܐܡܪܐ ܕܚܡܫܐ ܥܠ ܐܓܪܬܐ ܕܠܘܬ ܩܘܪ̈ܢܬܝܐ</quote>,
+                    <locus>fol. 20 a</locus>; <quote xml:lang="syr">ܡܢ ܐܓܪܬܐ ܕܐܬܟ̣ܬܒܬ ܠܘܬ
+                    ܢܣܛܪܝܣ</quote>
+                  <quote xml:lang="en">(the twelve anathemas)</quote>, <locus>fol. 20 b</locus>.</p>
+                <p><persName>John of Jerusalem</persName>: <quote xml:lang="syr">ܡܢ ܣܝܡܐ ܕܥܠ
+                    ܗܝܡܢܘܬܐ</quote>, <locus>fol. 21 b</locus>.</p>
+                <p><persName ref="http://syriaca.org/person/786">Theodotus of Ancyra</persName>:
+                    <quote xml:lang="syr">ܡܢ ܡܐܡܪܐ ܕܥܠ ܝܠܕܗ ܕܡܫܝܚܐ</quote>, <locus>fol. 22
+                  b</locus>.</p>
+                <p><persName ref="http://syriaca.org/person/688">Proclus of
+                    Constantinople</persName>: <quote xml:lang="syr">ܡܢ ܬܘܪܓܡܐ ܕܥܠ ܝܠܕܗ
+                    ܕܡܫܝܚܐ</quote>, <locus>fol. 24 a</locus>.</p>
+                <p><persName>Dioscorus of Alexandria</persName>: <quote xml:lang="syr">ܡܢ ܐܓܪܬܐ
+                    ܕܐܬܟ̣ܬܒܬ ܡܢ ܐܟܣܘܪܝܐ ܕܒܓܢܓܪܐ ܠܘܬ</quote>
+                  <quote xml:lang="grc">(ἐνατον)</quote>
+                  <quote xml:lang="syr">ܕܝܪ̈ܝܐ ܕܗܢܛܘܢ</quote>, <locus>fol. 25 a</locus>.</p>
+              </note>
+            </msItem>
+            <msItem>
+              <locus to="" from="26a"/>
+              <author ref="http://syriaca.org/person/579">Julian of Halicarnassus</author>
+              <title ref="" xml:lang="en">The eight chapters of Julian of Halicarnassus, with
+                refutations</title>
+              <rubric xml:lang="syr">ܩ̈ܦܠܐܐ ܕܝܘܠܝܢܐ ܗܪܛܝܩܐ: ܗ̇ܢܘܢ ܕܘ̇ܠܐ ܕܢܗܘܐ ܥܠܝܗܘܢ ܦܝܣܐ
+                ܕܬܪܥܝܬܐ</rubric>
+              <incipit xml:lang="syr"/>
+              <quote xml:lang="syr">
+                <locus from="" to=""/>
+              </quote>
+              <explicit xml:lang="syr">
+                <locus to="" from=""/>
+              </explicit>
+              <finalRubric xml:lang="syr">
+                <locus to="" from=""/>
+              </finalRubric>
+              <note>The authorities cited are— <p><persName>Athanasius</persName>: <quote xml:lang="syr">ܡܢ ܡܐܡܪܐ ܕܬܠܬܐ
+                  ܕܟܬܒܐ ܕܥܠ ܬܠܝܬܝܘܬܐ. ܕܠܘܩܒܠ ܐܪ̈ܝܢܘ ܕܠܐ ܐܠܗ</quote>, <locus>foll. 32 a, 37 b</locus>; <quote xml:lang="syr">ܡܢ ܡܐܡܪܐ ܕܡܪܬܝܢܘܬܐ
+                  ܡܛܠ ܕܢܚܗ ܦܓܪܢܝܐ ܕܡܪܢ ܘܦܪܘܩܢ ܝܫܘܥ ܡܫܝܚܐ.</quote>, <locus>fol. 32 b</locus>.</p>
+                <p><persName ref="http://syriaca.org/person/573">Chrysostom</persName>: on the <ref target="http://syriaca.org/work/9646">Gospel of S. Matthew</ref>, <locus>fol. 38 a</locus>; of <ref target="http://syriaca.org/work/9641">S. John</ref>, <locus>foll. 33 b, 34 a</locus>;
+                  on the <ref target="http://syriaca.org/work/9594">Epistle to the Romans</ref>, <locus>fol. 28 a</locus>; <ref target="http://syriaca.org/work/9607">to the Hebrews</ref>, <locus>fol. 34 b</locus>.</p>
+                <p><persName ref="http://syriaca.org/person/430">Cyril of Alexandria</persName>: <quote xml:lang="syr">ܡܢ ܐܝܠܝܢ ܕܠܘܬ ܕܝܕܘܪܘܣ</quote>, <locus>fol. 27 b</locus>; comment. on <ref target="http://syriaca.org/work/9641">the Gospel
+                  of S. John</ref>, <locus>foll. 27 b, 28 b, 36 a and b</locus>; Thesaurus, <locus>foll. 30 b, 31 a, 32 a</locus>; <quote xml:lang="syr">ܡܢ
+                  ܫܪܝܐ ܕܦܣܩܐ ܕܨܝܕ ܫܘܐܠܐ ܕܐܢܫ ܛܝܒܪܝܘܣ ܡܫܡܫܢܐ ܘܕܐ̈ܚܐ ܕܥܡܗ</quote>, <locus>fol. 33 a</locus>; <quote xml:lang="syr">ܐܓܪܬܐ ܕܠܘܬ ܐܩܩ
+                  ܐܦܣܩܦܐ ܕܣܩܘܬܐܦܘܠܝܣ ܡܢ ܬܐܘܪ̈ܝܐ ܕܥܙܙܐܝܠ</quote>, <locus>fol. 37 a</locus>.</p>
+                <p><persName ref="http://syriaca.org/person/1708">Epiphanius</persName>: <quote xml:lang="syr">ܕܩܕܝܫܐ ܐܦܝܦܢܝܣ ܐܦܣܩܦܐ ܕܣܠܡܝܢܐ ܡܢ ܟܬܒܐ ܐܢܩܪܛܢ</quote>, <locus>fol. 38 b</locus>.</p>
+                <p><persName ref="http://syriaca.org/person/512">Gregory Nyssen</persName>: <quote xml:lang="syr">ܡܢ ܡܐܡܪܐ ܕܡܪܬܝܢܘܬܐ</quote>, <locus>fol. 30 a</locus>; <quote xml:lang="syr">ܡܢ ܡܐܡܪܐ ܕܬܠܬܐ ܡܢ ܐܝܠܝܢ ܕܠܘܩܒܠ
+                  ܐܘܢܡܝܣ</quote>, <locus>fol. 38 a</locus>.</p>
+                <p><persName ref="http://syriaca.org/person/513">Gregory Thaumaturgus</persName>: <quote xml:lang="syr">ܡܢ ܡܐܡܪܐ ܕܥܠ ܡܬܒܣܪܢܘܬܐ ܘܗܝܡܢܘܬܐ ܒܦܘܫܩܐ ܕܚܪܡܐ ܕܬܪ̈ܝܢ</quote>, <locus>fol.
+                  31 a</locus>; <quote xml:lang="syr">ܒܦܘܫܩܐ ܗ̇ܘ ܕܚܪܡܐ ܩܕܡܝܐ</quote>, <locus>fol. 31 b</locus>; <quote xml:lang="syr">ܡܢ ܣܝܡܐ ܕܗܝܡܝܘܬܐ ܕܒܡܢ̈ܘܬܐ</quote>, <locus>fol. 32
+                  a</locus>.</p>
+                <p><persName ref="http://syriaca.org/person/544">Ignatius of Antioch</persName>: <quote xml:lang="syr">ܡܢ ܐܓܪܬܐ ܕܠܘܬ ܐܦܣ̈ܝܐ.</quote>, <locus>fol. 37 b</locus>.</p>
+                <p><persName>John of Jerusalem</persName>: <quote xml:lang="syr">ܕܩܕܝܫܐ ܝܘܚܢܢ ܐܦܣܩܦܐ ܕܐܪܫܠܡ: ܗ̇ܘ ܕܒ̈ܝܘܡܬܗ ܐܫܬܟܚ ܦܓܪܗ ܝܩܝܪܐ
+                  ܕܐܣܛܦܢܘܣ ܪܫܐ ܕܣ̈ܗܕܐ̇. ܐܝܠܝܢ ܕܣܡ ܒܡܟܬܒܢܘܬܗ ܕܥܠ ܪܫܝܥܬܐ ܣܘܢܗܕܘܣ ܕܟܠܩܕܘܢܐ. ܫ̇ܘܐ
+                  ܠܕܘܟܪܢܐ ܕܐܬܠܛܘܬܐ ܛܝܡܬܐܣ ܐܦܣܩܦܐ ܕܐܠܟܣܢܕܪܝܐ.</quote> , <locus>fol. 29 a</locus>.</p>
+                <p><persName ref="http://syriaca.org/person/688">Proclus of Constantinople</persName>: <quote xml:lang="syr">ܡܢ ܐܓܪܬܐ ܕܨܝܕ ܐܪ̈ܡܢܝܐ.</quote>, <locus>fol. 29 a</locus>.</p>
+                <p><persName>Severus of Antioch</persName>: <locus>fol. 26 a</locus>.</p>
+              </note>
+            </msItem>
+            <msItem>
+              <locus to="" from=""/>
+              <author ref=""/>
+              <title ref="" xml:lang="en">A collection of the Canons of the principal Councils of
+                the Church</title>
+              <rubric xml:lang="syr"/>
+              <incipit xml:lang="syr"/>
+              <quote xml:lang="syr">
+                <locus from="" to=""/>
+              </quote>
+              <explicit xml:lang="syr">
+                <locus to="" from=""/>
+              </explicit>
+              <finalRubric xml:lang="syr">
+                <locus to="" from=""/>
+              </finalRubric>
+              <note>
+                <p>a. Of <placeName ref="http://syriaca.org/place/621">Nicaea</placeName>. <locus>Fol. 40 a</locus>.</p>
+                <p>b. Of <placeName ref="http://syriaca.org/place/494">Ancyra</placeName>. <locus>Fol. 44 b</locus>.</p>
+                <p>c. Of <placeName ref="http://syriaca.org/place/466">Neo-Caesarea</placeName>. <locus>Fol. 48 b</locus>.</p>
+                <p>d. Of <placeName ref="http://syriaca.org/place/10">Antioch</placeName>. <locus>Fol. 50 a</locus>.</p>
+                <p>e. Of <placeName ref="http://syriaca.org/place/2677">Laodicea</placeName>. <locus>Fol. 56 a</locus>.</p>
+              </note>
+            </msItem>
+            <msItem>
+              <locus to="" from=""/>
+              <author ref="http://syriaca.org/person/44">Philoxenus of Mabūg</author>
+              <title ref="" xml:lang="en">Writings of Philoxenus of Mabūg</title>
+              <rubric xml:lang="syr"/>
+              <incipit xml:lang="syr"/>
+              <quote xml:lang="syr">
+                <locus from="" to=""/>
+              </quote>
+              <explicit xml:lang="syr">
+                <locus to="" from=""/>
+              </explicit>
+              <finalRubric xml:lang="syr">
+                <locus to="" from=""/>
+              </finalRubric>
+              <note/>
+              <msItem>
+                <locus to="" from="61a"/>
+                <author ref="">Abū Nafīr, στρατηλύτης, of al-Hīra</author>
+                <author ref="http://syriaca.org/person/44">Philoxenus of Mabūg</author>
+                <title ref="" xml:lang="en">Letter to Abū Nafīr, στρατηλύτης, of al-Hīra, giving
+                  some account of <persName ref="http://syriaca.org/person/655">Nestorius</persName>, <persName ref="http://syriaca.org/person/780">Theodore of
+                    Mopsuestia</persName>, <persName ref="http://syriaca.org/person/482">Eutyches</persName>,
+                    <persName>Dioscorus</persName>, and the Councils of Ephesus and
+                  Chalcedon</title>
+                <rubric xml:lang="syr">ܣܘܢܗܕܝܩܘܣ ܕܟܬ̣ܒ ܡܪܝ ܐܟܣܢܝܐ ܐܦܣܩܦܐ ܕܡܒܘܓ. ܠܐܒܘ ܢܝܦܝܪ ܣܛܪܛܠܛܣ
+                  ܕܚܝܪܬܐ ܕܒܝܬ ܢܥܡܢ</rubric>
+                <incipit xml:lang="syr"/>
+                <quote xml:lang="syr">
+                  <locus from="" to=""/>
+                </quote>
+                <explicit xml:lang="syr">
+                  <locus to="" from=""/>
+                </explicit>
+                <finalRubric xml:lang="syr">
+                  <locus to="" from=""/>
+                </finalRubric>
+                <note/>
+              </msItem>
+              <msItem>
+                <locus to="" from="65b"/>
+                <author ref="http://syriaca.org/person/44">Philoxenus of Mabūg</author>
+                <title ref="" xml:lang="en">A short tract on various heresies
+                  (<persName>Manes</persName>, <persName ref="http://syriaca.org/person/616">Marcion</persName>,
+                  <persName ref="http://syriaca.org/person/482">Eutyches</persName>; <persName ref="http://syriaca.org/person/2779">Valentinus</persName>,
+                  <persName>Bardesanes</persName>; <persName ref="http://syriaca.org/person/2499">Apollinaris</persName>;
+                  <persName>Eunomius</persName>; <persName>Diodorus</persName>, <persName ref="http://syriaca.org/person/780">Theodore
+                    of Mopsuestia</persName>, <persName ref="http://syriaca.org/person/781">Theodoret</persName>,
+                  <persName ref="http://syriaca.org/person/655">Nestorius</persName>, etc.; <persName ref="http://syriaca.org/person/2486">Arius</persName>; <persName ref="http://syriaca.org/person/2469">Paul
+                    of Samosata</persName>; the council of Chalcedon; the Jews), concluding with the
+                  orthodox profession of faith</title>
+                <rubric xml:lang="syr">ܥܠ ܦܘܪܫܐ ܕܗܪ̈ܣܝܣ ܗܠܝܢ ܕܒܛܥܝܘܬܐ ܐܚܝܕܝܢ</rubric>
+                <incipit xml:lang="syr"/>
+                <quote xml:lang="syr">
+                  <locus from="" to=""/>
+                </quote>
+                <explicit xml:lang="syr">
+                  <locus to="" from=""/>
+                </explicit>
+                <finalRubric xml:lang="syr">
+                  <locus to="" from=""/>
+                </finalRubric>
+                <note/>
+              </msItem>
+              <msItem>
+                <locus to="" from="66b"/>
+                <author ref="http://syriaca.org/person/44">Philoxenus of Mabūg</author>
+                <title ref="" xml:lang="en">Seven chapters, anathematizing
+                  <persName ref="http://syriaca.org/person/655">Nestorius</persName>, <persName>Diodorus of Tarsus</persName>,
+                  <persName ref="http://syriaca.org/person/780">Theodore of Mopsuestia</persName>, and the Diphysites, and accepting
+                  the Henoticon (ܗܢܛܝܩܘܢ ܗܢܘ ܕܝܝܼܢ ܡܚܝܕܢܐ) and the twelve chapters of <persName>Cyril</persName></title>
+                <rubric xml:lang="syr">ܬܘܒ ܪ̈ܫܐ ܝܕܝ̈ܥܐ ܕܣܝܡܝܢ ܠܚܣܝܐ ܘܩܕܝܫܐ ܦܝܠܟܣܝܢܣ ܐܦܣܩܦܐ ܕܡܒܘܓ.
+                  ܕܘ̇ܠܐ ܕܢܚܪܡ ܠܟܠ ܕܢܣܛܘܪܝܢܐ ܗܘ. ܘܨ̇ܒܐ ܕܢܥ̇ܒܪ ܡܢܗ ܣܘܓܐܐ ܕܨܘܚܝܐ.</rubric>
+                <incipit xml:lang="syr"/>
+                <quote xml:lang="syr">
+                  <locus from="" to=""/>
+                </quote>
+                <explicit xml:lang="syr">
+                  <locus to="" from=""/>
+                </explicit>
+                <finalRubric xml:lang="syr">
+                  <locus to="" from=""/>
+                </finalRubric>
+                <note/>
+              </msItem>
+              <msItem>
+                <locus to="" from="68a"/>
+                <author ref="http://syriaca.org/person/44">Philoxenus of Mabūg</author>
+                <title ref="" xml:lang="en">Confession of Faith, in ten heads, directed against the
+                  council of Chalcedon</title>
+                <rubric xml:lang="syr">ܗܝܡܢܘܬܐ ܕܐܚ̣ܪܡܬ ܡܢ ܥܕܬܐ .. ܗܢܐ ܡܕܡ ܕܣܪܚ̣ܬ ܣܘܢܗܕܣ
+                  ܕܟܠܩܕܘܢܐ</rubric>
+                <incipit xml:lang="syr">܏ܐ. ܡܚܪܡܝܢ ܚܢܢ ܠܣܘܢܗܕܘܣ ܕܟܠܩܕܘܢܐ. ܡܛܠ ܕܐܚ̣ܪܡܬ ܠܣܘܢܗܕܣ
+                  ܫܪܝܪܬܐ̇. ܕܐܒ̈ܗܝܢ ܩ̈ܕܝܫܐ̇. ܬܠܬܡܐܐ ܘܬܡܢܬܥܣܪ..</incipit>
+                <quote xml:lang="syr">
+                  <locus from="" to=""/>
+                </quote>
+                <explicit xml:lang="syr">
+                  <locus to="" from=""/>
+                </explicit>
+                <finalRubric xml:lang="syr">
+                  <locus to="" from=""/>
+                </finalRubric>
+                <note/>
+              </msItem>
+              <msItem>
+                <locus to="" from="69a"/>
+                <author ref="http://syriaca.org/person/44">Philoxenus of Mabūg</author>
+                <title ref="" xml:lang="en">Three additional chapters against heresies</title>
+                <rubric xml:lang="syr">ܪ̈ܫܐ ܩ̈ܕܡܝܐ ܕܣܝܡܝܢ ܠܡܪܝ ܐܟܣܢܝܐ ܐܦܣܩܦܐ ܕܡܒܘܓ. ܠܘܩܒܠ ܗܪ̈ܣܝܣ
+                  ܕܡܩܪ̈ܒܢ ܥܡ ܥܕܬܐ</rubric>
+                <incipit xml:lang="syr"/>
+                <quote xml:lang="syr">
+                  <locus from="" to=""/>
+                </quote>
+                <explicit xml:lang="syr">
+                  <locus to="" from=""/>
+                </explicit>
+                <finalRubric xml:lang="syr">
+                  <locus to="" from=""/>
+                </finalRubric>
+                <note/>
+              </msItem>
+              <msItem>
+                <locus to="" from="69b"/>
+                <author ref="http://syriaca.org/person/44">Philoxenus of Mabūg</author>
+                <title ref="" xml:lang="en">Reply to be made by any one, when questioned as to his
+                  belief</title>
+                <rubric xml:lang="syr">ܦܘܢܝ ܦܬܓܡܐ ܡܐ ܕܡܫܬ̇ܐܠ ܐܢܫ ܕܐܝܟܢܐ ܡܗ̇ܝܡܢ ܐܢܬ.</rubric>
+                <incipit xml:lang="syr">ܗܝܡܢܘܬܝ̣ ܒܬܠܝܬܝܘܬܐ ܗܝ. ܘܬܠܝܬܝܘܬܐ̣ ܠܐ ܒܨܝܪܐ ܘܚܣܝܪܐ ܕܬܗܘܐ
+                  ܬܪܝܢܘܬܐ ܘܠܐ ܡܬܬܘܣܦ ܥܠܝܗ̇ ܕܬܪܒ̣ܐ ܒܐܪܒܝܥܝܘܬܐ. ܠܐ ܡܢ ܫܘܡܠܝܗ̇ ܚܣܝܪܐ̣. ܘܠܐ ܩܢܘܡܐ ܐܚܪܢܐ
+                  ܠܒܪ ܡܢܗ̇ ܡܩ̇ܒܠܐ. ܏ܘܫ..</incipit>
+                <quote xml:lang="syr">
+                  <locus from="" to=""/>
+                </quote>
+                <explicit xml:lang="syr">
+                  <locus to="" from=""/>
+                </explicit>
+                <finalRubric xml:lang="syr">
+                  <locus to="" from=""/>
+                </finalRubric>
+                <note/>
+              </msItem>
+              <msItem defective="true">
+                <locus to="" from="71a"/>
+                <author ref="http://syriaca.org/person/44">Philoxenus of Mabūg</author>
+                <author ref="http://syriaca.org/person/33">Isaac of Antioch</author>
+                <title ref="" xml:lang="en">Questions of Isaac of Antioch, in the form of a dialogue
+                  between pupil and teacher</title>
+                <rubric xml:lang="syr">܏ܫܘܐ̈ܠܐ ܏ܕܡܪܝ ܏ܐܝܣܚܩ ܏ܡܠܦܢܐ̣ ܘܬܠܡܝܕܗ ܏ܬܠܡܝܕܐ ܏ܐܡ̇ܪ ܘ̇ܠܐ
+                  ܕܢܨ̇ܠܐ ܐܚܐ ܩܕܡ ܟܗܢܐ܆ ܏ܡܠܦܢܐ ܏ܐܡ̇ܪ ܐܚܐ ܕܢܨ̇ܠܐ ܐܘ ܕܢܬܚܫܚ ܒܫܘܠܛܢܐ ܕܟܗܢܘܬܐ ܠܐ ܫܠܝܛ ܠܗ.
+                  ܐܢ ܓܝܪ ܠܡ̈ܐܬܝܢ ܘܚܡܫܝܢ ܓܒܪ̈ܝܢ ܠܘ̈ܝܐ: ܗ̇ܢܘܢ ܕܐܝܟ ܗܘ̈ܦܘܕܝܩܢܐ ܐܝܬܝܗܘܢ ܗܘܘ: ܥܠ ܕܐܡܪ̣ܚܘ
+                  ܘܣܡܘ ܒܣ̈ܡܐ ܒܫܘܠܛܢܐ ܕܟܗܢܘܬܐ ܢܦ̣ܩܬ ܢܘܪܐ ܡܢ ܦܘܡ̈ܝܗܘܢ ܘܐܘܩ̣ܕܬ ܐܢܘܢ܆ ܐܝܟܢܐ ܐܚܐ ܫܚܝܡܐ̇
+                  ܫܠܝܛ ܠܗ ܕܢܬܚ̇ܫܚ ܒܫܘܠܛܢܐ ܕܟܗܢܘܬܐ.</rubric>
+                <incipit xml:lang="syr"/>
+                <quote xml:lang="syr">
+                  <locus from="" to=""/>
+                </quote>
+                <explicit xml:lang="syr">
+                  <locus to="" from=""/>
+                </explicit>
+                <finalRubric xml:lang="syr">
+                  <locus to="" from=""/>
+                </finalRubric>
+                <note>These questions are written in a different hand from the rest of the
+                  manuscript, but of not much later date.</note>
+              </msItem>
+            </msItem>
+          </msContents>
+          <physDesc>
+            <objectDesc form="codex">
+              <supportDesc material="perg">
+                <extent>
+                  <measure unit="content_pending" quantity="-1"/>
+                </extent>
+                <foliation/>
+                <collation/>
+                <condition>
+                  <list>
+                    <item>
+                      <p>Vellum, about 9 5/8 in. by 6 1/8, consisting of 72 leaves, a few of which
+                        are slightly stained and the last much torn. The quires, 8 in number, are
+                        signed with letters from ܝܘ to ܟܓ. Leaves are wanting after foll. 71 and 72.
+                        Each page is divided into two columns, of from 29 to 35 lines. This volume
+                        is written in a good, regular Estrangělā of the viith or viiith cent.</p>
+                    </item>
+                  </list>
+                </condition>
+              </supportDesc>
+              <layoutDesc>
+                <p>Content pending</p>
+              </layoutDesc>
+            </objectDesc>
+            <handDesc>
+              <handNote scope="" script=""
+                medium="">
+                <desc></desc>
+              </handNote>
+            </handDesc>
+            <additions>
+              <p></p>
+              <list>
+                <item>
+                  <locus from="1a" to=""/>
+                  <p>Fol. 1 a contains an account of some visions of <persName>Antony</persName>,
+                    ܛܘܒܢܐ ܐܢܛܘܢ, imperfect at the beginning, owing to the fly-leaf having been lost.
+                    The writing seems to be of the <date>ixth cent</date>. At the foot of the page
+                    is a note in the same hand, stating that the book was bound by the monk
+                      <persName>John of Kěphar-Yambū</persName></p>
+                  <p><quote xml:lang="syr">ܕܒ̇ܩ̣ ܟܬܒܐ ܗܢܐ̣. ܝܘܚܢܢ ܛ̇ܘܒܢܐ ܕܟܦܪܝܢܒܘ ܨ̇ܠܘ ܥܠܘܗܝ.</quote></p>
+                </item>
+              </list>
+            </additions>
+            <bindingDesc>
+              <p>Content pending</p>
+            </bindingDesc>
+            <sealDesc>
+              <p>Content pending</p>
+            </sealDesc>
+            <accMat/>
+          </physDesc>
+          <history>
+            <origin>
+              <origDate notBefore="0600" notAfter="0800" from="" to="" when="">viith or viiith
+                cent.</origDate>
+              <origPlace ref="" xml:lang=""></origPlace>
+            </origin>
+            <provenance/>
+            <acquisition/>
+          </history>
+          <additional/>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>Content pending</p>
+    </encodingDesc>
+    <profileDesc/>
+    <revisionDesc status="draft">
+      <change when="" who="http://syriaca.org/documentation/editors.xml#cchen">Initial TEI encoding.</change>
+      <change type="planned" subtype="checkSyriac">The Syriac copied from the Word Document needs to
+        be checked for accuracy: "needs footnote for Syriac" in section 6a, 920 wright</change>
+      <change type="planned" subtype="question">Question in Word Doc to be Addressed: The addition
+        has a different date than the rest of the manuscript</change>
+    </revisionDesc>
+  </teiHeader>
+  <facsimile>
+    <formula>Content pending</formula>
+  </facsimile>
+  <text>
+    <body>
+      <bibl>Content pending</bibl>
+    </body>
+  </text>
+</TEI>

--- a/data/3_drafts/ClaireChen/29A.xml
+++ b/data/3_drafts/ClaireChen/29A.xml
@@ -1,0 +1,813 @@
+<?xml version="1.0" encoding="utf-8"?>
+<?oxygen RNGSchema="https://raw.githubusercontent.com/wlpotter/syriaca-wright-catalog/master/schemas/enrich-syriaca.rnc" type="compact"?>
+<?xml-stylesheet type="text/css" href="https://raw.githubusercontent.com/srophe/wright-catalogue/master/parameters/wright-mss.css"?>
+<TEI xml:lang="en" xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader xmlns="http://www.tei-c.org/ns/1.0">
+    <fileDesc>
+      <titleStmt>
+        <title>Content pending</title>
+      </titleStmt>
+      <editionStmt>
+        <p>Content pending</p>
+      </editionStmt>
+      <publicationStmt>
+        <p>Content pending</p>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <idno type="URI">29</idno>
+            <altIdentifier>
+              <idno type="BL-Shelfmark">Add. 12,154</idno>
+            </altIdentifier>
+          </msIdentifier>
+          <msContents>
+            <summary/>
+            <textLang mainLang="syr"/>
+            <msItem>
+              <locus to="" from="1b"/>
+              <author ref=""/>
+              <title ref="" xml:lang="grc">Πληροφορία</title>
+              <title ref="" xml:lang="en">Defense of the orthodox and apostolic faith<note>being a
+                  defense of Monophysite doctrines, principally directed against the
+                  Nestorians</note></title>
+              <rubric xml:lang="syr">ܦܠܝܪܘܦܘܪܝܐ ܐܘ ܟܝܬ ܡ̣ܦܩ ܒܪܘܚܐ ܕܗܝܡܢܘܬܐ ܬܪܝܨܬ ܫܘܒܚܐ
+                ܘܫܠܝܚܝܘܬܐ</rubric>
+              <incipit xml:lang="syr">ܡܛܠ ܕܐܢ̈ܫܝܢ ܡܢ ܐܝ̇ܕܐ ܥܠ̣ܬܐ ܠܐ ܝܕܥ̇ܝܢܢ: ܐܠܐ ܐܢ ܕܠܡܐ ܡܢ ܚܛܗ̈ܐ
+                ܕܝܠܢ: ܘܡܢ ܡܥܒܕܢܘܬܐ ܕܐܟܠܩܪܨܐ ܗ̇ܘ ܚܣ̇ܡ ܒܫܦܝܪ̈ܬܐ ܥ̇ܕܠܝܢ: ܘܪ̈ܘܪܒܬܐ ܪܫ̇ܝܢ ܠܡܣܟܢܘܬܐ ܕܝܠܢ
+                ܐܝܟ ܡ̇ܢ ܕܠܐ ܨ̇ܒܝܢܢ: ܏ܘܫ.</incipit>
+              <quote xml:lang="syr">
+                <locus from="" to=""/>
+              </quote>
+              <explicit xml:lang="syr">
+                <locus to="" from=""/>
+              </explicit>
+              <finalRubric xml:lang="syr">
+                <locus to="" from=""/>
+              </finalRubric>
+              <note>The author commences by assigning the false statements and abusive language of
+                the opponents of his way of thinking, as his principal reason for writing this
+                defense of the faith: <quote xml:lang="syr">ܒܙܒܢ ܕܝܢ: ܣܕ̈ܘܩܐ ܘܝܥܩܘ̈ܒܝܛܐ ܘܐܩ̈ܦܠܘ ܐܘ ܟܝܬ ܕܠܐ ܪܝܫܐ ܩ̇ܪܝܢ ܠܢ:
+                ܘܒܚ̈ܣܕܐ ܐܚܪ̈ܢܐ ܘܡܘ̈ܝܩܐ ܡܗ̇ܠܝܢ ܒܢ. ܐܝܬ ܕܝܢ ܐܡܬܝ: ܕܐܦ ܪ̈ܫܝܥܐ ܘܡ̈ܛܥܝܢܐ ܘܡܚ̈ܫܝ ܐܠܗܐ
+                ܡ̇ܟܢܝܢ ܠܢ: ܘܕܓܡܝܪܐܝܬ ܢܦܝ̇ܠܝܢ ܡܢ ܫܦܝܪܘܬ ܕܚܠܬܐ: ܏ܘܫ.</quote>
+              He then enters into a full statement of the monophysite doctrines (<locus>fol. 2 b</locus>),
+                for which he claims the support (<locus>fol. 6 b</locus>) of <persName>Ignatius</persName>,
+                  <persName>Julius</persName>, <persName>Athanasius</persName>,
+                  <persName>Basil</persName>, <persName>the three Gregories</persName>,
+                  <persName>Theophilus</persName>, <persName>Chrysostom</persName>,
+                  <persName>Epiphanius</persName>, <persName>Cyril</persName>,
+                <persName>Dioscorus</persName>, <persName>Timotheus</persName>, <persName ref="http://syriaca.org/person/51">Severus
+                  of Antioch</persName>, <persName ref="http://syriaca.org/person/44">Philoxenus of Mabūg</persName>,
+                <persName>Theodosius of Alexandria</persName>, and <persName ref="http://syriaca.org/person/1592">Anthimus of
+                  Constantinople</persName>; and concludes by bringing forward a considerable number
+                of testimonies from these and other writers, which he has arranged in three
+                chapters, <locus>fol. 7 b</locus>.<quote xml:lang="syr">ܟܕ ܗܠܝܢ ܗܟܝܠ ܗܟܢܐ ܐܡܝܪ̈ܢ̣. ܕܐܠܨܐ ܐܬܚ̇ܫܒܢ̣ܢ. ܘܕܩܠܝܠ
+                    ܡܢ ܣ̇ܓܝ ܟܪ̈ܝܣܝܣ ܘܣܗ̈ܕܘܬܐ ܕܐܒܗ̈ܬܐ ܩ̈ܕܝܫܐ ܘܕܡ̈ܠܦܢܐ ܠܐ ܛܥ̈ܘܫܐ ܕܥܕܬܐ̇. ܒܬܠܬܐ ܩ̈ܦܠܐܐ
+                    ܢܣ̣ܝܡ̇. ܒܗܕܐ ܦܠܪܘܦܘܪܝܐ. ܠܘܬ ܗܝܡܢܘܬܐ(ܓܠܝܘܬܐ (marg. ܡ̇ܢ ܘܫ̇ܘܪ̈ܪܐ ܕܕܘ̈ܓܡܛܐ ܕܝܠܢ
+                    ܐܠܗ̈ܝܐ ܘܬܪ̈ܝܨܝ ܫܘܒܚܐ ܗܠܝܢ ܕܩ̇ܕܝܡܝܢ ܟܬܝܒܝ̣ܢ. ܠܘܬ ܡܟܣܢܘܬܐ ܕܝܢ ܘܗܦܘܟܝܐ ܕܝ̈ܘܠܦܢܐ
+                    ܗܠܝܢ ܬܪ̈ܝܝ ܟܝ̈ܢܐ ܘܢܣܛܘܪ̈ܝܢܐ. ܀ . ܘܩܦܠܐܘܢ ܡ̇ܢ ܩܕܡܝܐ ܡ̇ܚܘܐ̣. ܕܝܠܕܬ ܐܠܗܐ ܐܝܬܝܗ̇
+                    ܒܬܘܠܬܐ ܩܕܝܫܬܐ ܡܪܝܡ̣. ܐܝܟ ܡ̇ܢ ܕܠܐܠܗܐ ܕܐܬܒ̇ܣܪ ܡܢܗ̇ ܝܠ̣ܕܬ݀. ܘܠܘ ܠܒܪܢܫܐ ܕܗ̣ܘܐ ܐܠܗܐ̇.
+                    ܐܝܟ ܡܐ ܕܢܣܛܘܪ̈ܝܢܘ ܦܠܚ̈ܝ ܠܒܪܢܫܐ ܐܡ̇ܪܝܢ . ܀ . ܩܦܠܐܘܢ ܕܝܢ ܗ̇ܘ ܕܐܬܪܝܢ ܡܫܘܕܥ̣. ܕܚܕ
+                    ܐܝܬܘܗܝ ܡܫܝܚܐ: ܘܚܕ ܟܝܢܐ ܐܘ ܟܝܬ ܩܢܘܡܐ ܕܝܠܗ ܕܡ̇ܒܣܪ݂. ܘܠܘ ܬܪܝܢ ܟܝ̈ܢܐ ܐܘ ܩܢܘ̈ܡܐ̇.
+                    ܐܝܟܢܐ ܕܐܡ̇ܪܝܢ ܗܠܝܢ ܕܢܣܛܘܪܝܢܝܣܐ ܥܒ̇ܕܝܢ. ܀ . ܘܩܦܠܐܘܢ ܗ̇ܘ ܕܬܠܬܐ ܡ̇ܩܝܡ̣. ܕܐܠܗܐ ܡܠܬܐ
+                    ܗ̇ܘ ܝܚܝܕܝܐ. ܕܐܒܐ ܗ̇ܘ ܚܕ ܡܢ ܬܠܝܬܝܘܬܐ ܟܕ ܐܬܒܪܢܫ ܚܫ ܘܐܨܛܠܒ ܚܠܦܝܢ ܒܒܣܪ݂. ܘܠܘ ܒܪܢܫܐ
+                    ܐܢܫ ܫܚܝܡܐ ܠܦܘܪܩܢܐ ܕܝܠܢ ܥܒ̣ܕ܇ ܐܝܟܢܐ ܕܬܘܒ ܘܗܕܐ ܗܠܝܢ ܗܪ̈ܣܝܘܛܐ ܐܡ̇ܪܝܢ.</quote></note>
+              <note>The authorities cited are— 
+                <p>1. <persName>Acacius of Melitene</persName>:
+                  letter to <persName>Cyril</persName>. <locus>Fol. 11 a</locus>.</p>
+                <p>2. <persName>Alexander of Alexandria</persName>: <quote xml:lang="syr">ܡܢ ܡܐܡܪܐ ܕܐܝܬܘܗܝ ܪܝܫܗ ܫ̣ܡܥܘ ܡ̈ܠܐ ܕܫܪܪܐ.</quote> <locus>Fol. 13
+                  b.</locus></p>
+                <p>3. <persName>Athanasius</persName>: <quote xml:lang="syr">ܡܢ ܐܓܪܬܐ ܕܠܘܬ ܝܘܒܢܝܢܘܣ ܡ̇ܠܟܐ </quote>, <locus>fol. 8 b</locus>; <quote xml:lang="syr">ܡܢ ܡܐܡܪܐ ܕܠܘܩܒܠ ܐܪ̈ܝܢܘ. ܕܡ̇ܝܬܐ ܠܗ̇ ܩܕܝܫܐ ܩܘܪܝܠܘܣ܆ ܒܐܓܪܬܐ ܕܠܘܬ
+                    ܕܝܪ̈ܝܐ̇. ܗܝ . . .</quote>, imperfect, <locus>fol. 8 b</locus>;<quote xml:lang="syr">ܡܢ ܟܬܒܐ ܕܡܛܠ ܡܬܒܣܪܢܘܬܐ ܕܐܠܗܐ ܡܠܬܐ. ܕܐܬܬ̣ܝܬܝܬ̇ ܡܢ ܩܕܝܫܐ
+                    ܩܘܪܝܠܘܣ܆ ܒܗܠܝܢ ܕܠܘܬ ܬܐܘܕܘܪܝܛܐ ܕܩܘܪܘܣ. ܘܒܗܠܝܢ ܕܠܘܬ ܐܢܕܪܐܐ ܗ̇ܘ ܕܫܡܝܫܛ ܗ̇ܢܘܢ
+                    ܪ̈ܫܝܥܐ. ܘܒܗܠܝܢ ܕܠܘܬ ܡܠܟܬܐ ܫܦܝܪܬ ܕܚܠܬܐ</quote>, <locus>fol. 9 b</locus>; <quote xml:lang="syr">ܡܢ ܡܐܡܪܐ ܕܠܘܩܒܠ ܐܦܘܠܝܢܪܝܘܣ ܗ̇ܘ ܕܪܝܫܗ̣ ܙܢܐ ܡ̇ܢ ܕܕܚܠܬ
+                    ܐܠܗܐ ܗ̇ܘ ܕܕܠܐ ܥܡ̣ܠܐ</quote>, <locus>fol. 14 a</locus>; <quote xml:lang="syr">ܡܢ ܐܓܪܬܐ ܕܠܘܬ ܐܦܝܩܛܝܛܘܣ ܐܦܝܣܩܘܦܐ ܕܩܘܪܢܬܘܣ. ܗ̇ܝ ܕܪܝܫܗ̣̇ ܐܢܐ ܡ̇ܢ ܣ̇ܒܪ
+                    ܗܘܝܬ</quote>, <locus>fol. 14 b</locus>.</p>
+                <p>4. <persName>Basil</persName>: <quote xml:lang="syr">ܡܢ
+                    ܐܓܪܬܐ ܕܠܘܬ ܐܡܦܝܠܘܟܝܘܣ ܕܡܛܠ ܪܘܚܐ ܩܕܝܫܐ and ܡܢ ܡܐܡܪܐ ܕܥܠ ܝܘܠܝܛܐ ܣܗܕܬܐ ܘܡܛܠ
+                    ܬܘܕܝܬܐ.</quote><locus>Fol. 14 b</locus>.</p>
+                <p>5. <persName>Chrysostom</persName>: hom. xvii. on <ref target="http://syriaca.org/work/9596">2nd Corinthians</ref>. Fol. 15 b.</p>
+                <p>6. <persName ref="http://syriaca.org/person/430">Cyril of Alexandria</persName>:
+                    <quote xml:lang="syr">ܡܢ ܐܓܪܬܐ ܕܬܠܬ ܕܠܘܬ ܢܣܛܘܪܝܘܣ</quote>, <locus>fol. 10
+                    a</locus>; <quote xml:lang="syr">ܡܢ ܐܓܪܬܐ ܩܕܡܝܬܐ ܕܠܘܬ ܣܘܩܢܣܘܣ</quote>,
+                    <locus>fol. 10 b</locus>; <quote xml:lang="syr">ܡܢ ܐܓܪܬܐ ܕܠܘܬ ܐܩܩ ܏ܐܦܝܣ
+                    ܕܡܝܠܝܛܝܢܐ</quote>, <locus>fol. 10 b</locus>; <quote xml:lang="syr">ܡܢ ܐܓܪܬܐ ܕܠܘܬ
+                    ܐܘܠܘܓܝܘܣ</quote>
+                  <quote xml:lang="grc">(ἀποκρισιάριος)</quote>
+                  <quote>ܐܦܘܩܪܝܣܪܐ</quote><locus>fol. 10 b</locus>; <quote xml:lang="syr">ܡܢ ܡܐܡܪܐ
+                    ܦܪܘܣܦܘܢܛܝܩܘܢ</quote>
+                  <quote xml:lang="grc">(προσφωνητικόν)</quote>
+                  <quote>ܕܠܘܬ ܕܚ̇ܠ ܠܐܠܗܐ ܡ̇ܠܟܐ ܬܐܘܕܘܣܝܘܣ</quote><locus>fol. 10 b</locus>; <quote xml:lang="syr">ܡܢ ܡܦܩ ܒܪܘܚܐ ܕܚܪܡܐ ܕܥܣܪܐ ܕܠܘܬ ܥ̈ܘܕܠܐ ܕܪܫܝܥܐ ܬܐܘܕܘܪܝܛܐ</quote>,
+                    <locus>fol. 10 b</locus>; <quote xml:lang="syr">ܡܢ ܐܓܪܬܐ ܕܠܘܬ ܕܝܪ̈ܝܐ. ܕܐܝܬܘܗܝ
+                    ܪܝܫܗ̇. ܐܬ݂ܘ ܡ̇ܢ ܐܢ̈ܫܝܢ </quote>, <locus>fol. 16 a</locus>; <quote xml:lang="syr">ܡܢ ܟܬܒܐ ܕܬܪܥܣܪ̈ ܕܦܘܫܩܐ ܕܐܘܢܓܠܝܘܢ ܕܡܬܝ</quote>, <locus>fol. 16 a</locus>.</p>
+                <p>7. <persName ref="http://syriaca.org/person/431">Cyril of Jerusalem</persName>: <quote xml:lang="syr"><locus from="15a" to=""/>ܡܢ ܡܫܡܥܢܘܬܐ ܕܬܠܬܥܣܪܐ.</quote> Fol. 15 a.</p>
+                <p>8. <persName>Dionysius of Alexandria</persName>: <quote xml:lang="syr"><locus from="8a, 13b" to=""/>ܡܢ ܐܓܪܬܐ ܕܠܘܬ ܦܘܠܐ ܫܡܝܫܛܝܐ. ܕܐܝܬܘܗܝ ܪܝܫܗ̣̇. ܘܩܕܡܐܝܬ ܟܕ
+                    ܟܬ̣ܒܬ.</quote> Foll. 8 a, 13 b.</p>
+                <p>9. <persName>Dioscorus of Alexandria</persName>: ܡܢ ܐܓܪܬܐ ܕܠܘܩܒܠ ܗܪ̈ܛܝܩܘ ܗ̇ܝ
+                  ܕܪܝܫܗ̣̇. ܐܝܠܝܢ ܕܠܘܬ ܢܝ̣ܫܐ ܕܙܟܘܬܐ ܕܩܪܝܬܐ ܗ̇ܝ ܕܠܥܠ ܪܗܝܒܝܢ ܠܡܪܗܛ[ܚܦܝܛܝܢ [variant, $
+                  Foll. 12 b, 16 a.</p>
+                <p>10. <persName>Erechtheus (ܐܪܟܬܐܘܣ) of Antioch in Pisidia</persName>: <quote xml:lang="syr">ܡܢ ܬܘܪܓܡܐ ܕܐܬܐ̣ܡܪ ܡܢܗ ܒܝܬ ܕܢܚ̣ܐ ܐܠܗܝܐ̇.
+                    ܒܥܕܬܐ ܪܒܬܐ ܕܩܘܣܛܢܛܝܢܦܘܠܝܣ܇ ܟܕ ܝܬܝܒ ܛܘܒܬܢܐ ܦܪܘܩܠܘܣ ܐܦܝܣܩܦܐ ܕܝܠܗ̇ ܕܡܕܝܢܬܐ</quote>,
+                  <locus>fol. 12 a</locus>; <quote xml:lang="syr">ܡܢ ܡܐܡܪ ܕܥܠ ܒܝܬ
+                    ܝܠܕܐ.</quote>, <locus>fol. 12 a and b</locus>.</p>
+                <p>11. <persName>Gelasius (ܓܠܣܝܘܣ) of Caesarea in Palestine</persName>: <quote xml:lang="syr">ܡܢ ܡܐܡܪܐ ܗ̇ܘ ܕܥܠ ܗ̇ܝ ܕܦ̣ܫ ܝܥܩܘܒ ܒܠܚܘܕܘܗܝ
+                    ܘܡܩܪܒ ܗܘܐ ܓܒܪܐ ܥܡܗ.</quote> <locus>Fol. 15 a</locus>.</p>
+                <p>12. <persName ref="http://syriaca.org/person/511">Gregory Nazianzen</persName>: <quote xml:lang="syr">ܡܢ ܡܐܡܪܐ ܕܥܠ ܩܒܘܪܬܐ ܕܩܕܝܫܐ ܒܣܝܠܝܘܣ ܐܓܪܬܐ ܕܠܘܬ
+                    ܩܠܝܕܘܢܝܘܣ.</quote> <locus>Fol. 15 a</locus>.</p>
+                <p>13. <persName ref="http://syriaca.org/person/513">Gregory
+                  Thaumaturgus</persName>: <quote xml:lang="syr">ܡܢ ܗܝܡܢܘܬܐ ܗ̇ܝ ܕܒܡ̈ܢܘܬܐ ܕܒܐܝ̣ܕܐ
+                    ܒܐܝ̣ܕܐ</quote>
+                  <quote xml:lang="grc">(ἡ κατὰ μέρος πίστις).</quote>
+                  <locus>Fol. 9 a</locus>.</p>
+                <p>14. <persName>Ignatius</persName>: <quote xml:lang="syr">ܡܢ ܐܓܪܬܐ ܕܠܘܬ ܪ̈ܘܡܝܐ.</quote> <locus>Fol. 13 a</locus>.</p>
+                <p>15. <persName>Irenaeus</persName>: <quote xml:lang="syr">ܡܢ ܟܬܒܐ ܕܚܡܫܐ ܕܡܟܣܢܘܬܐ ܘܗܦܘܟܝܐ ܕܝܕܥܬܐ ܕܓܠ̣ܬ̇ ܫܡܐ.</quote> <locus>Fol. 13 a</locus>.</p>
+                <p>16. <persName ref="http://syriaca.org/person/2163">Julius of Rome</persName>: <quote xml:lang="syr">ܡܢ ܡܐܡܪܐ ܗ̇ܘ ܕܠܘܬ ܗܢ̇ܘܢ ܕܡܬܟܬܫܝܢ ܠܘܩܒܠ ܡܬܒܣܪܢܘܬܐ ܐܠܗܝܬܐ̇.
+                    ܒܥܠܬܐ ܕܗ̇ܝ ܕܫܘ̣̇ܐ ܒܐܘܣܝܐ.</quote>, <locus>fol. 8 a and b</locus>; <quote xml:lang="syr">ܡܢ ܡܐܡܪܐ ܕܪܫܝܡ ܥܠܘܗܝ ܡܛܠ ܚܕܝܘܬܐ ܕܒܡܫܝܚܐ ܕܦܓܪܐ ܠܘܬ ܐܠܗܘܬܗ
+                    ܕܐܠܗܐ ܡܠܬܐ.</quote>, <locus>fol. 9 a</locus>; <quote xml:lang="syr">ܡܢ
+                    ܐܓܪܬܐ ܕܠܘܬ ܕܝܘܢܘܣܝܘܣ ܐ܏ܦܝܣ ܕܩܘܪܢܬܘܣ</quote>, <locus>fol. 9 b</locus>.</p>
+                <p>17. <persName>Peter of Alexandria</persName>: <quote xml:lang="syr">ܡܢ ܟܬܒܐ ܕܡܛܠ ܐܠܗܘܬܐ.</quote> <locus>Fol. 8 b</locus>.</p>
+                <p>18. <persName ref="http://syriaca.org/person/688">Proclus of Constantinople</persName>, <quote xml:lang="syr">ܡܢ ܐܓܪܬܐ ܕܠܘܬ ܐܪ̈ܡܢܝܐ.</quote> <locus>Fol. 11 b</locus>.</p>
+                <p>19. <persName ref="http://syriaca.org/person/51">Severus of Antioch</persName>: <quote xml:lang="syr">ܡܢ ܡܐܡܪܐ ܏ܕܣܙ ܕܐܦܝܬܪܘܢܝܘ܇ ܐܘ ܟܝܬ ܕܥܠ ܩܕܝܫܬܐ ܝ̇ܠ̣ܕܬ ܐܠܗܐ
+                    ܡܪܝܡ</quote>, <locus>fol. 9 a</locus>; <quote xml:lang="syr">ܡܢ ܡܐܡܪܐ
+                    ܩܕܡܝܐ ܕܠܘܬ ܢܝܦܠܝܘܣ</quote>, <locus>fol. 13 a</locus>; <quote xml:lang="syr">ܡܢ ܩܦܠܐܘܢ ܕܬܠܬܝܢ ܘܬܠܬܐ ܕܡܐܡܪܐ ܕܬܠܬܐ ܕܠܘܩܒܠ ܓܪܡܛܝܩܘܣ ܩܣܪܝܐ</quote>, <locus>fol.
+                  16 b</locus>.</p>
+                <p>20. <persName ref="http://syriaca.org/person/786">Theodotus of Ancyra</persName>: <quote xml:lang="syr">ܡܢ ܡܐܡܪܐ ܕܥܠ ܒܝܬ ܝܠܕܐ</quote>, <locus>fol. 11 a</locus>;
+                  <quote xml:lang="syr">ܡܢ ܡܐܡܪܐ ܕܡܛܠ ܝܠܝܕܘܬܐ</quote>, <locus>fol. 11 a</locus>; <quote xml:lang="syr">ܡܢ ܦܘܫܩܐ ܕܬܚܘܡܐ</quote>, <locus>fol. 11 b</locus>.</p>
+              </note>
+            </msItem>
+            <msItem>
+              <locus to="" from="17a"/>
+              <author ref=""/>
+              <title ref="" xml:lang="en"><note>A tract in defence of Monophysite doctrines</note>
+                Demonstrations, or Evidences, concerning the Dispensation of the Messiah <note>divided
+                  into fifteen chapters</note></title>
+              <rubric xml:lang="syr">ܬܚ̈ܘܝܬܐ ܐܚܪ̈ܢܝܬܐ̣ ܕܥܠ ܡܕܒܪܢܘܬܗ ܕܡܫܝܚܐ.</rubric>
+              <incipit xml:lang="syr"/>
+              <quote xml:lang="syr">܏ܐ. ܩܦܠܐܘܢ ܩܕܡܝ̣ܐ. ܥܠ ܗ̇ܝ ܕܚܕ ܦܪܨܘܦܐ ܡܪܟܒܐ ܐܝܬܘܗܝ ܡܫܝܚܐ. ܏ܒ ܥܠ
+                ܗ̇ܝ ܕܠܚܕܝܘܬܐ ܕܡܠܬܐ ܕܠܘܬ ܒܣܪܗ ܡܢܦܫܐ̣. ܟܝܢܝܬܐ ܘܩܢܘܡܝܬܐ ܝܕܥܝܢ ܐܒ̈ܗܬܐ̣. ܘܕܒܐܘܣܝܐ ܐܬܚܝܕ
+                ܡ̇ܠܦܝܢ. ܏ܓ ܥܠ ܗ̇ܝ ܕܗ̇ܘ ܕܡܬܪܟ̇ܒ ܒܚܕܝܘܬܐ ܟܝܢܝܬܐ ܡܢ ܣܘܥܪ̈ܢܐ ܡܫ̈ܚܠܦܝ ܒܟܝܢܐ̣. ܡܫܬܡܗ ܡܢ
+                ܡܢ̈ܘܬܗ. ܘܟܠܗ ܡܢ ܟܠܚܕܐ ܡܢܗܝܢ ܡܬܩܪܐ̣. ܘܟܠܚܕܐ ܡܢܗܝ̣ܢ ܡܫܬܡܗܐ ܒܫܡܐ ܕܟܘܠܝܘܬܗ. ܏ܘܫ.. <locus to="" from="17a"/></quote>
+              <explicit xml:lang="syr">
+                <locus to="" from=""/>
+              </explicit>
+              <finalRubric xml:lang="syr">
+                <locus to="" from=""/>
+              </finalRubric>
+              <note>The Fathers cited are— <p>1. <persName>Athanasius</persName>: <quote xml:lang="syr">ܡܢ ܣܝ̇ܡܐ ܕܥܠ ܬܠܝܬܝܘܬܐ̇. ܘܡܛܠ ܡܬܒܪܢܫܢܘܬܗ
+                    ܕܡܠܬܐ̣ ܘܠܘܩܒܠ ܐܦܘܠܘܢܪ̈ܝܣܛܐ</quote>, <locus>fol. 17 a</locus>; <quote xml:lang="syr">ܡܢ ܡܐܡܪܐ ܕܥܠ ܗܝܡܢܘܬܐ</quote>, <locus>fol. 19 a</locus>; <quote xml:lang="syr">ܡܢ ܐܓܪܬܐ ܕܠܘܬ ܝܘܒܝܢܝܢܘܣ ܡ̇ܠܟܐ</quote>,
+                  <locus>fol. 20 a</locus>; <quote xml:lang="syr">ܡܢ ܐܓܪܬܐ ܕܠܘܬ
+                    ܐܦܝܩܛܝܛܘܣ</quote>, <locus>fol. 27 b</locus>.</p>
+                <p>2. <persName ref="http://syriaca.org/person/573">Chrysostom</persName>: hom. viii. on the <ref target="http://syriaca.org/work/9599">Epistle to the
+                  Philippians</ref>, and hom. ii. on the <ref target="http://syriaca.org/work/9607">Epistle to the Hebrews</ref>. <locus>Fol.
+                  18 b</locus>.</p>
+                <p>3. <persName ref="http://syriaca.org/person/430">Cyril of Alexandria</persName>: <quote xml:lang="syr">ܡܢ ܡܐܡܪܐ ܦܪܘܣܦܘܢܛܝܩܘܢ ܕܠܘܬ ܡ̇ܠܟܐ
+                  ܬܐܘܕܘܣܝܣ</quote>, <locus>fol. 19 b</locus>; <quote xml:lang="syr">ܡܢ ܡܐܡܪܐ ܕܐܝܟ ܕܒܫܘܐܠܐ ܘܦܘܢܝ ܦܬܓܡܐ</quote>, <locus>fol. 20 a</locus>; <quote xml:lang="syr">ܡܢ ܡܐܡܪܐ ܗ̇ܘ
+                      ܕܚܕ ܗܘ ܡܫܝܚܐ</quote>, <locus>foll. 21 a, 26 a</locus>; <quote xml:lang="syr">ܡܢ ܣܟܘܠܝܘܢ ܕ܏ܝܓ</quote>, <locus>fol. 18 b</locus>; <quote xml:lang="syr">ܡܢ ܪܘܫܡܐ ܕܣܟܘܠܝܘܢ
+                          ܕ܏ܝܐ</quote>, <locus>fol. 24 a</locus>; <quote xml:lang="syr">ܡܢ ܛܘܡܣܐ ܕܬܪܝܢ ܕܠܘܩܒܠ ܓܘ̈ܕܦܐ ܕܢܣܛܘܪܝܘܣ</quote>, <locus>foll. 21 b, 23 b, 24 b</locus>; 
+                  <quote xml:lang="syr">ܡܢ ܛܘܡܣܐ ܕܚܡܫܐ ܕܠܘܩܒܠ ܓܘ̈ܕܦܘܗܝ
+                    ܕܢܣܛܘܪܝܘܣ</quote>, <locus>foll. 26 a, 27 b</locus>; <quote xml:lang="syr">ܡܢ ܐܓܪܬܐ ܕܠܘܬ
+                      ܐܘܠܘܓܝܘܣ</quote>, <locus>foll. 20 a, 22 b</locus>; <quote xml:lang="syr">ܡܢ ܐܓܪܬܐ ܕܠܘܬ ܐܩܩ ܐ܏ܦܝܣ ܕܡܠܝܛܝܢܐ</quote>, <locus>foll. 19 b, 20 a, 23
+                  b</locus>; <quote xml:lang="syr">ܡܢ ܐܓܪܬܐ ܩܕܡܝܬܐ ܕܠܘܬ ܣܘܩܢܣܘܣ</quote>, <locus>foll. 19 b, 26 b</locus>; <quote xml:lang="syr">ܡܢ ܐܓܪܬܐ ܕܬܪܬܝܢ</quote>, <locus>foll. 20 b, 21
+                  a, 22 b, 23 a, 27 a</locus>; <quote xml:lang="syr">ܡܢ ܐܓܪܬܐ ܕܠܘܬ ܘܠܝܪܝܢܐ ܐܦܝܣܩܘܦܐ</quote>, <locus>fol. 24 b</locus>; <quote xml:lang="syr">ܡܢ ܐܓܪܬܐ ܕܬܠܬ ܕܠܘܬ
+                    ܢܣܛܘܪܝܘܣ ܕܒܗ̇ ܣܝ̣ܡܝܢ ܚܪ̈ܡܐ ܗܠܝܢ ܏ܝܒ</quote>, <locus>foll. 21 b, 24 a</locus>; <quote xml:lang="syr">ܚܪ̈ܡܐ̣ ܕܬܪܝܢ</quote>, <locus>fol. 17 b</locus>;
+                  <quote xml:lang="syr">ܚܪܡܐ ܕ܏ܓ</quote>, <locus>foll. 17 b, 24 a</locus>; <quote xml:lang="syr">ܡܢ ܦܘܫܩܐ ܕܚܪܡܐ ܗ̇ܘ ܕܬܠܬܐ</quote>, <locus>fol. 24 a</locus>; <quote xml:lang="syr">ܡܢ ܡܦܩ ܒܪܘܚܐ
+                    ܕܚ̣ܪܡܐ ܕܬܪܝܢ ܕܠܘܬ ܬܐܘܕܘܪܝܛܐ</quote>, <locus>fol. 17 b</locus>; <quote xml:lang="syr">ܡܢ ܡܦܩ ܒܪܘܚܐ ܕܚܪܡܐ ܕ܏ܓ ܕܨܝܕ ܥ̈ܘܕܠܐ
+                      ܕܬܐܘܕܘܪܝܛܐ.</quote>, <locus>foll. 17 a and b, 23 b, 24 a</locus>; <quote xml:lang="syr">ܡܢ ܡܦܩ ܒܪܘܚܐ ܕܚܪܡܐ ܪܒܝܥܝܐ ܕܠܘܬ ܥ̈ܘܕܠܐ
+                        ܕܬܐܘܕܘܪܝܛܐ</quote>, <locus>fol. 27 a</locus>; <quote xml:lang="syr">ܡܢ ܡܦ̣ܩ ܒܪܘܚܐ ܕܚܪܡܐ ܕܚܡܫܐ</quote>, <locus>fol. 27 a</locus>; <quote xml:lang="syr">ܡܢ ܡܦܩ ܒܪܘܚܐ ܕܚܪܡܐ
+                          ܕܫܬܐ</quote>, <locus>fol. 23 b</locus>; <quote xml:lang="syr">ܡܢ ܡܦܩ ܒܪܘܚܐ ܕܚܪܡܐ ܕܬܡ̈ܢܝܐ ܕܠܘܬ ܥ̈ܘܕܠܐ ܕܐܢܕܪܐܐ</quote>, <locus>fol. 21 b</locus>; <quote xml:lang="syr">ܡܢ ܡܦܩ ܒܪܘܚܐ ܕܚܪܡܐ ܕܥܣܪܐ</quote>, <locus>foll. 19 b, 23 a</locus>.</p>
+                <p>4. <persName>Dionysius the Areopagite</persName>: <quote xml:lang="syr">ܡܢ ܡܐܡܪܐ ܕܥܠ ܟܘ̈ܢܝܐ ܐܠܗ̈ܝܐ.</quote>
+                  <locus>Fol. 19 a</locus>.</p>
+                <p>5. <persName ref="http://syriaca.org/person/511">Gregory Nazianzen</persName>: <quote xml:lang="syr">ܡܢ ܐܓܪܬܐ ܕܠܘܬ ܩܠܝܕܘܢܝܘܣ.</quote> <locus>Fol. 17
+                  b.</locus></p>
+                <p>6. <persName ref="http://syriaca.org/person/2163">Julius of Rome</persName>: <quote xml:lang="syr">ܡܢ ܐܓܪܬܐ ܕܠܘܬ ܦܪܘܣܕܘܩܝܘܣ.</quote> <locus>Fol. 26 a</locus>.</p>
+                <p>7. <persName ref="http://syriaca.org/person/51">Severus of Antioch</persName>: without title, <locus>fol. 20 b</locus>; <quote xml:lang="syr">ܡܢ ܐܓܪܬܐ
+                  ܕܠܘܬ ܡܪܘܢ ܕܪܝܫܗ̣̇ ܟܕ ܡܢ ܩܕܝܡ ܩ̇ܒܠܬ ܐܓܪܬܐ ܕܪܚܡ̣ܬ ܐܠܗܐ ܕܝܠܟ.</quote>, <locus>fol. 18 a</locus>; <quote xml:lang="syr">ܡܢ ܐܓܪܬܐ
+                    ܕܠܘܬ ܬܐܘܡܐ ܣܘܢܩܠܐ</quote>, <locus>fol. 25 b</locus>; <quote xml:lang="syr">ܡܢ ܩܦܠܐܘܢ ܏ܕܙ ܕܡܐܡܪܐ ܏ܐ ܕܠܘܩܒܠ ܓܪܡܛܝܩܘܣ</quote>, <locus>fol. 27 b</locus>;
+                  <quote xml:lang="syr">ܡܢ ܩܦܠܐܘܢ ܕ܏ܟܐ ܕܡܐܡܪܐ ܏ܕܒ</quote>, <locus>fol. 25 a</locus>; <quote xml:lang="syr">ܡܢ ܩܦܠܐܘܢ ܏ܕܟܓ ܕܡܐܡܪܐ ܏ܕܒ</quote>, <locus>fol. 25 a</locus>.</p>
+                <p>8. Acts of the Council of Antioch, which deposed <persName ref="http://syriaca.org/person/2469">Paul of
+                  Samosata</persName>: <quote xml:lang="syr">ܡܢ ܣܝ̇ܡܐ ܕܗܝܡܢܘܬܐ ܕܣܘܢܘܕܘܣ ܩܕܝܫܬܐ ܗ̇ܝ ܕܐܬܟܢ̣ܫܬ ܒܐܢܛܝܘܟܝܐ
+                    ܘܫ̣ܕܬ ܠܦܘܠܐܫܡܝܫܛܝܐ</quote>, <locus>fol. 17 a</locus>; <quote xml:lang="syr">ܡܢ ܐܓܪܬܐ ܐܢܩܘܩܠܝܘܢ ܕܣܘܢܘܕܘܣ ܗܝ̇ ܕܫ̣ܕܬ ܠܦܘܠܐ
+                      ܫܡܝܫܛܝܐ</quote>, <locus>fol. 18 a</locus>; <quote xml:lang="syr">ܕܝܠܗ ܟܕ ܕܝܠܗ̇ ܕܣܘܢܘܕܘܣ̣. ܡܢ ܗܘܦܡ̈ܢܡܛܐ ܕܝܠܗ̣̇. ܡܢ ܕܪܫܐ ܕܥܒ̣ܕ
+                  ܡ̇ܠܟܝܘܢ ܩܫܝܫܐ ܒܡܦܣܢܘܬܗ̇ ܠܘܩܒܠ ܦܘܠܐ.</quote>, <locus>fol. 18 a</locus>.</p>
+              </note>
+              <note>Quotations from Scripture: the <ref target="http://syriaca.org/work/9641">Gospel of S. John, ch. viii. 40</ref>, <locus>fol.
+                18 a</locus>; <ref target="http://syriaca.org/work/9593">Acts, ch. ii. 22</ref>, <locus>fol. 18 a</locus>; <ref target="http://syriaca.org/work/9595">1st Corinth., ch. ii. 8</ref>,
+                <locus>fol. 18 b</locus>, <ref target="http://syriaca.org/work/9595">ch. xv. 21</ref>, <locus>fol. 18 a</locus>; <ref target="http://syriaca.org/work/9597">Galat., ch. i. 1, 11</ref>, <locus>fol.
+                18 b</locus>; <ref target="http://syriaca.org/work/9607">Hebr., ch. i. 3</ref>, <locus>fol. 18 b</locus>.</note>
+            </msItem>
+            <msItem>
+              <locus to="" from=""/>
+              <author ref=""/>
+              <title ref="" xml:lang="en">Extracts and selections from the writings of various
+                fathers. Many of these are abridged, so as to give merely the sense of the author </title>
+              <rubric xml:lang="syr">ܐܝܟ ܕܒܚܝܠܐ</rubric>
+              <incipit xml:lang="syr"/>
+              <quote xml:lang="syr">
+                <locus from="" to=""/>
+              </quote>
+              <explicit xml:lang="syr">
+                <locus to="" from=""/>
+              </explicit>
+              <finalRubric xml:lang="syr">
+                <locus to="" from=""/>
+              </finalRubric>
+              <note/>
+              <msItem>
+                <locus to="" from="28a, 31a"/>
+                <author ref="http://syriaca.org/person/537">Hippolytus</author>
+                <title ref="" xml:lang="en">Hippolytus</title>
+                <rubric xml:lang="syr">ܡ̈ܠܐ ܡܓܒ̈ܝܬܐ ܡܢ ܟܬܒܐ ܕܩܕܝܫܐ ܐܝܦܘܠܝܛܘܣ ܕܦܘܫܩܐ ܕܕܢܝܐܝܠ ܢܒܝܐ̣.
+                  ܕܫܩ̣̈ܝܠܢ ܐܝܟ ܕܒܚܝܠܐ ܒܠܚܘܕ<locus to="" from="28a"/></rubric>
+                <rubric xml:lang="syr">ܬܘܒ ܕܝܠܗ ܕܟܕ ܕܝܠܗ ܕܩܕܝܫܐ ܐܝܦܘܠܝܛܘܣ̣. ܣܟܘܠܝܘܢ̣ ܡܛܠ ܦܘܪܫܐ
+                    ܕܡܙܡܘܪ̈ܐ.<locus to="" from="31a"/></rubric>
+                <incipit xml:lang="syr"/>
+                <quote xml:lang="syr">
+                  <locus from="" to=""/>
+                </quote>
+                <explicit xml:lang="syr">
+                  <locus to="" from=""/>
+                </explicit>
+                <finalRubric xml:lang="syr">
+                  <locus to="" from=""/>
+                </finalRubric>
+                <note>Edited by <bibl>de Lagarde, Anal. Syr., pp. 79—87</bibl>. </note>
+                <note>Compare <persName>Ceriani</persName>'s notes to the photo-lithographed edition
+                  of the <bibl>Codex Ambrosianus, pp. 3, 4</bibl>.</note>
+              </msItem>
+              <msItem>
+                <locus to="" from="33b"/>
+                <author ref="http://syriaca.org/person/537">Origen</author>
+                <title ref="" xml:lang="en">Origen</title>
+                <rubric xml:lang="syr">ܣܟܘܠܝܘܢ ܐܚܪܢܐ̣ ܕܐܘܪܓܝܢܝܘܣ܀ ܙܕ݁ܩ ܕܝܢ ܠܡܒܥܐ̣. ܕܡܛܠ ܡܢܐ ܏ܩܢ
+                  ܒܠܚܘܕ ܐܝܬܝܗܘܢ ܡܙܡܘܪ̈ܐ.</rubric>
+                <incipit xml:lang="syr"/>
+                <quote xml:lang="syr">
+                  <locus from="" to=""/>
+                </quote>
+                <explicit xml:lang="syr">
+                  <locus to="" from=""/>
+                </explicit>
+                <finalRubric xml:lang="syr">
+                  <locus to="" from=""/>
+                </finalRubric>
+                <note>Translated by <bibl>Cowper in his Syriac Miscellanies, p. 57</bibl>.</note>
+              </msItem>
+              <msItem>
+                <locus to=""/>
+                <author ref=""/>
+                <title ref="" xml:lang="en">Part 3</title>
+                <rubric xml:lang="syr"/>
+                <incipit xml:lang="syr"/>
+                <quote xml:lang="syr">
+                  <locus from="" to=""/>
+                </quote>
+                <explicit xml:lang="syr">
+                  <locus to="" from=""/>
+                </explicit>
+                <finalRubric xml:lang="syr">
+                  <locus to="" from=""/>
+                </finalRubric>
+                <note/>
+                <msItem>
+                  <locus to="" from="34a"/>
+                  <author ref="">Athanasius</author>
+                  <title ref="" xml:lang="en">Athanasius on <ref target="http://syriaca.org/work/9672">Pss. xl. 8 (Ilcb. x. 5), lxxi. 15,
+                      xlviii. 2, xlix. 2, lxxviii. 25</ref></title>
+                  <rubric xml:lang="syr"/>
+                  <incipit xml:lang="syr"/>
+                  <quote xml:lang="syr">
+                    <locus from="" to=""/>
+                  </quote>
+                  <explicit xml:lang="syr">
+                    <locus to="" from=""/>
+                  </explicit>
+                  <finalRubric xml:lang="syr">
+                    <locus to="" from=""/>
+                  </finalRubric>
+                  <note/>
+                </msItem>
+                <msItem>
+                  <locus to="" from="35a"/>
+                  <author ref="">Severus</author>
+                  <title ref="" xml:lang="en">Severus on <ref target="http://syriaca.org/work/9672">Ps. li. 5</ref></title>
+                  <rubric xml:lang="syr">ܡܢ ܟܬܒܐ ܕܠܘܩܒܠ ܬܘ̈ܣܦܬܗ ܕܝܘܠܝܢܐ</rubric>
+                  <incipit xml:lang="syr"/>
+                  <quote xml:lang="syr">
+                    <locus from="" to=""/>
+                  </quote>
+                  <explicit xml:lang="syr">
+                    <locus to="" from=""/>
+                  </explicit>
+                  <finalRubric xml:lang="syr">
+                    <locus to="" from=""/>
+                  </finalRubric>
+                  <note/>
+                </msItem>
+                <msItem>
+                  <locus to="" from="35b"/>
+                  <author ref="">Cyril</author>
+                  <title ref="" xml:lang="en">Cyril on <ref target="http://syriaca.org/work/9672">Ps. Ii. 5</ref></title>
+                  <rubric xml:lang="syr">ܡܢ ܡܐܡܪܐ ܏ܕܝܗ ܕܬܫܡܫܬܐ ܕܪܘܚ</rubric>
+                  <incipit xml:lang="syr"/>
+                  <quote xml:lang="syr">
+                    <locus from="" to=""/>
+                  </quote>
+                  <explicit xml:lang="syr">
+                    <locus to="" from=""/>
+                  </explicit>
+                  <finalRubric xml:lang="syr">
+                    <locus to="" from=""/>
+                  </finalRubric>
+                  <note/>
+                </msItem>
+                <msItem>
+                  <locus to="" from="35b"/>
+                  <author ref="">Severus</author>
+                  <title ref="" xml:lang="en">Severus on a passage in the book of
+                    <ref target="http://syriaca.org/work/9535">Job</ref></title>
+                  <rubric xml:lang="syr">ܡܢܗ ܕܟܬܒܐ ܕܠܘܩܒܠ ܬܘ̈ܣܦܬܐ ܕܝܘܠܝܢܐ</rubric>
+                  <rubric xml:lang="syr">ܦܘܫܩܐ̣ ܕܗ̇ܝ ܕܐܡ̣ܪ ܐܝܘܒ ܕܠܝܬ ܕܕܟ̣̇ܐ ܡܢ ܨܐܬܐ ܕܚܛܝ̣ܬܐ̣
+                      ܘܕܫܪܟܐ.</rubric>
+                  <incipit xml:lang="syr"/>
+                  <quote xml:lang="syr">
+                    <locus from="" to=""/>
+                  </quote>
+                  <explicit xml:lang="syr">
+                    <locus to="" from=""/>
+                  </explicit>
+                  <finalRubric xml:lang="syr">
+                    <locus to="" from=""/>
+                  </finalRubric>
+                  <note/>
+                </msItem>
+              </msItem>
+              <msItem>
+                <locus to="" from="36a"/>
+                <author ref="http://syriaca.org/person/452">Dionysius the Areopagite</author>
+                <title ref="" xml:lang="en">Dionysius the Areopagite: extracts</title>
+                <rubric xml:lang="syr">ܡܢ ܡܐܡܪܐ ܕܥܠ ܛܟܣ̣ܐ ܕܟܗܢܘܬܐ ܘܥܠ ܪ̈ܐܙܐ ܐܠܗ̈ܝܐ ܕܡܫܬܡܠܝܢ
+                    ܒܥܕܬܐ</rubric>
+                <incipit xml:lang="syr"/>
+                <quote xml:lang="syr">
+                  <locus from="" to=""/>
+                </quote>
+                <explicit xml:lang="syr">
+                  <locus to="" from=""/>
+                </explicit>
+                <finalRubric xml:lang="syr">
+                  <locus to="" from=""/>
+                </finalRubric>
+                <note/>
+              </msItem>
+              <msItem>
+                <locus to="" from=""/>
+                <author ref=""/>
+                <title ref="" xml:lang="en">Part 5</title>
+                <rubric xml:lang="syr"/>
+                <incipit xml:lang="syr"/>
+                <quote xml:lang="syr">
+                  <locus from="" to=""/>
+                </quote>
+                <explicit xml:lang="syr">
+                  <locus to="" from=""/>
+                </explicit>
+                <finalRubric xml:lang="syr">
+                  <locus to="" from=""/>
+                </finalRubric>
+                <note/>
+                <msItem>
+                  <locus to="" from="37b"/>
+                  <author ref="http://syriaca.org/person/430">Cyril of Alexandria</author>
+                  <title ref="" xml:lang="en">Cyril of Alexandria on <ref target="http://syriaca.org/work/9632">Exod., ch. iii.
+                    5</ref>and on <ref target="http://syriaca.org/work/9632">Exod., cli. xii. 8</ref></title>
+                  <rubric xml:lang="syr">ܡܢ ܡܐܡܪܐ ܏ܕܒ ܕܬܫܡܫܬܐ ܕܪܘܚ</rubric>
+                  <incipit xml:lang="syr"/>
+                  <quote xml:lang="syr">
+                    <locus from="" to=""/>
+                  </quote>
+                  <explicit xml:lang="syr">
+                    <locus to="" from=""/>
+                  </explicit>
+                  <finalRubric xml:lang="syr">
+                    <locus to="" from=""/>
+                  </finalRubric>
+                  <note/>
+                </msItem>
+                <msItem>
+                  <locus to="" from="38a"/>
+                  <author ref="">Jacob of Batnae</author>
+                  <title ref="" xml:lang="en">Jacob of Batnae on <ref target="http://syriaca.org/work/9632">Exod., ch. xii.
+                    8</ref></title>
+                  <rubric xml:lang="syr">ܡܢ ܡܐܡܪܐ ܕܥܠ ܙܩܝܦܘܬܐ</rubric>
+                  <incipit xml:lang="syr"/>
+                  <quote xml:lang="syr">
+                    <locus from="" to=""/>
+                  </quote>
+                  <explicit xml:lang="syr">
+                    <locus to="" from=""/>
+                  </explicit>
+                  <finalRubric xml:lang="syr">
+                    <locus to="" from=""/>
+                  </finalRubric>
+                  <note/>
+                </msItem>
+                <msItem>
+                  <locus to="" from="38a"/>
+                  <author ref="">Cyril</author>
+                  <title ref="" xml:lang="en">Cyril</title>
+                  <rubric xml:lang="syr">ܡܢ ܡܐܡܪܐ ܏ܕܘ ܕܬܫܡܫܬܐ ܕܪܘܚ. ܡܛܠ ܡܢܚ̈ܫܢܐ</rubric>
+                  <incipit xml:lang="syr"/>
+                  <quote xml:lang="syr">
+                    <locus from="" to=""/>
+                  </quote>
+                  <explicit xml:lang="syr">
+                    <locus to="" from=""/>
+                  </explicit>
+                  <finalRubric xml:lang="syr">
+                    <locus to="" from=""/>
+                  </finalRubric>
+                  <note/>
+                  <msItem>
+                    <locus to="" from="38b"/>
+                    <author ref="">Cyril</author>
+                    <title ref="" xml:lang="en">Cyril on on <ref target="http://syriaca.org/work/9632">Exod., chh. xxxiv. 26</ref></title>
+                    <rubric xml:lang="syr">ܡܢ ܡܐܡܪܐ ܏ܕܛ</rubric>
+                    <incipit xml:lang="syr"/>
+                    <quote xml:lang="syr">
+                      <locus from="" to=""/>
+                    </quote>
+                    <explicit xml:lang="syr">
+                      <locus to="" from=""/>
+                    </explicit>
+                    <finalRubric xml:lang="syr">
+                      <locus to="" from=""/>
+                    </finalRubric>
+                    <note/>
+                  </msItem>
+                  <msItem>
+                    <locus to="" from="38b"/>
+                    <author ref="">Cyril</author>
+                    <title ref="" xml:lang="en">Cyril on <ref target="http://syriaca.org/work/9632">Exod., xxii. 30, xx. 26</ref></title>
+                    <rubric xml:lang="syr">ܡܢ ܡܐܡܪܐ ܕ܏ܝܒ</rubric>
+                    <incipit xml:lang="syr"/>
+                    <quote xml:lang="syr">
+                      <locus from="" to=""/>
+                    </quote>
+                    <explicit xml:lang="syr">
+                      <locus to="" from=""/>
+                    </explicit>
+                    <finalRubric xml:lang="syr">
+                      <locus to="" from=""/>
+                    </finalRubric>
+                    <note/>
+                  </msItem>
+                  <msItem>
+                    <locus to="" from="39a"/>
+                    <author ref="">Cyril</author>
+                    <title ref="" xml:lang="en">Cyril on <ref target="on Isaiah, chh. xxvi. 18, 20, xxvii. 11, xxviii. 1, 9—11, xxix. 11, 12, xxx. 6, 26, xxxii. 9, 20, xviii. 2, xxxviii., and xxxix., ">Isaiah, chh. xxvi. 18, 20, xxvii. 11,
+                        xxviii. 1, 9—11, xxix. 11, 12, xxx. 6, 26, xxxii. 9, 20, xviii. 2, xxxviii.,
+                        and xxxix</ref>.</title>
+                    <rubric xml:lang="syr"/>
+                    <incipit xml:lang="syr"/>
+                    <quote xml:lang="syr">
+                      <locus from="" to=""/>
+                    </quote>
+                    <explicit xml:lang="syr">
+                      <locus to="" from=""/>
+                    </explicit>
+                    <finalRubric xml:lang="syr">
+                      <locus to="" from=""/>
+                    </finalRubric>
+                    <note/>
+                  </msItem>
+                </msItem>
+                <msItem>
+                  <locus to="" from="44a"/>
+                  <author ref="">Severus</author>
+                  <title ref="" xml:lang="en">Severus on <ref target="http://syriaca.org/work/9640">Isaiah, ch. xix. 18</ref>.</title>
+                  <rubric xml:lang="syr"/>
+                  <incipit xml:lang="syr"/>
+                  <quote xml:lang="syr">
+                    <locus from="" to=""/>
+                  </quote>
+                  <explicit xml:lang="syr">
+                    <locus to="" from=""/>
+                  </explicit>
+                  <finalRubric xml:lang="syr">
+                    <locus to="" from=""/>
+                  </finalRubric>
+                  <note/>
+                </msItem>
+                <msItem defective="false">
+                  <locus to="" from="44b, 45b"/>
+                  <author ref="http://syriaca.org/person/113">Jacob of Edessa</author>
+                  <title ref="" xml:lang="en">notes by Jacob of Edessa</title>
+                  <rubric xml:lang="syr"/>
+                  <incipit xml:lang="syr"/>
+                  <quote xml:lang="syr">ܢܘܗܪܐ. ܙ̇ܕܩ ܠܡܕܥ ܕܗܕܐ ܡܕܝܢܬܐ̣. ܗܝ̣ ܐܝܬܝܗ̇ ܩܕܡܝܬܐ ܒܡܥܠܢܐ
+                    ܕܡܨܪܝܢ ܕܡܢ ܦܠܐܣܛܝ̣ܢܝ. ܥܠܘܗܝ ܕܢܚܠܐ ܐܘ ܟܝܬ ܪܓܠܬܐ ܗܝ̇ ܕܒܝܢܬ ܦܠܐܣܛܝܢܝ ܠܡܨܪܝ̣ܢ. ܡܢ
+                    ܣܛܪܐ ܡܥܪܒܝܐ. ܘܐܝܟ ܕܡܢ ܥܡܘܪ̈ܐ ܩܕܡܝ̈ܐ ܘܥܬ̈ܝܩܐ̣. ܡܬܩܪܝܐ ܗܘܬ ܒܙܒ̣ܢ ܥܪܫ. ܗ̇ܝ ܕܠܘܬ
+                    ܐܢ̈ܫܝܢ ܡܦܫ̈ܩܢܐ ܐܪܣ ܟܬܝܒܐ̇. ܡܛܠ ܕܠܐ ܡܫܟܚܝܢ ܝܘ̈ܢܝܐ ܠܡܐܡܪ ܘܠܐ ܥܐ̣ ܘܠܐ ܫܝܢ. ܘܒܬܪܟܢ
+                    ܐܬ̣ܩܪܝܬ ܡܢ ܐܚܪ̈ܢܐ̣ ܪܝܢܘܩܘܪܘܪܐ ܘܬܘܒ ܐܬܩ̣ܪܝܬ̇ ܡܢ ܝܘ̈ܢܝܐ ܦܐܩܝܣ̣ ܐܘ ܟܝܬ ܦܐܩܝܕܐ. ܘܐܦ
+                    ܗܫܐ̣ ܒܟܠܗܘܢ ܗܠܝܢ ܟܘܢ̈ܝܐ ܡܬܩܪܝܐ ܡܢ ܥ̇ܡܘܪ̈ܐ ܕܐܬܪܐ.<locus from="44b" to=""
+                    /></quote>
+                  <quote xml:lang="syr">ܢܘܗ̇ܪܐ. ܡܕܝܢܬ ܫܡܫܐ ܕܝܢ ܐܝܬܝܗ̣̇. ܐܝܠܝܦܘܠܝܣ܇ ܗܝ̇ ܕܡܬܩܪܝܐ ܒܟܬܒܐ
+                    ܒܝܬ ܫܡܫ܇ ܘܒܗ̇ ܐܝܬܝܗܘܢ ܒ̈ܬܐ ܗܠܝܢ ܪ̈ܘܪܒܐ ܕܡܠܟܘܬܐ ܕܡܨܪ̈ܝܐ̇. ܘܩ̇ܝ̈ܡܬܐ ܗܠܝܢ ܬܡ̈ܝܗܬܐ
+                    ܕܡܬܥܗܕ ܟܬܒܐ.<locus from="45b" to=""/></quote>
+                  <explicit xml:lang="syr">
+                    <locus to="" from=""/>
+                  </explicit>
+                  <finalRubric xml:lang="syr">
+                    <locus to="" from=""/>
+                  </finalRubric>
+                  <note/>
+                </msItem>
+              </msItem>
+              <msItem>
+                <locus to="" from=""/>
+                <author ref=""/>
+                <title ref="" xml:lang="en">Part 6</title>
+                <rubric xml:lang="syr"/>
+                <incipit xml:lang="syr"/>
+                <quote xml:lang="syr">
+                  <locus from="" to=""/>
+                </quote>
+                <explicit xml:lang="syr">
+                  <locus to="" from=""/>
+                </explicit>
+                <finalRubric xml:lang="syr">
+                  <locus to="" from=""/>
+                </finalRubric>
+                <note/>
+                <msItem>
+                  <locus to="" from="46a"/>
+                  <author ref="http://syriaca.org/person/573">John Chrysostom</author>
+                  <title ref="" xml:lang="en">Extracts from the homilies of John Chrysostom on the
+                    <ref target="http://syriaca.org/work/9641">Gospel of S. John, ch. i. 14, 15, 16, 42, 28. </ref></title>
+                  <rubric xml:lang="syr"/>
+                  <incipit xml:lang="syr"/>
+                  <quote xml:lang="syr">
+                    <locus from="" to=""/>
+                  </quote>
+                  <explicit xml:lang="syr">
+                    <locus to="" from=""/>
+                  </explicit>
+                  <finalRubric xml:lang="syr">
+                    <locus to="" from=""/>
+                  </finalRubric>
+                  <note/>
+                </msItem>
+                <msItem>
+                  <locus to="" from="47a"/>
+                  <author ref="">Severus</author>
+                  <title ref="" xml:lang="en">Severus on <ref target="http://syriaca.org/work/9641">S. John, ch. ii. 1—11</ref></title>
+                  <rubric xml:lang="syr">ܡܢ ܡܐܡܪܐ ܏ܕܩܝܛ ܕܐܦܝܬܪ̈ܘܢܝܘܢ</rubric>
+                  <incipit xml:lang="syr"/>
+                  <quote xml:lang="syr">
+                    <locus from="" to=""/>
+                  </quote>
+                  <explicit xml:lang="syr">
+                    <locus to="" from=""/>
+                  </explicit>
+                  <finalRubric xml:lang="syr">
+                    <locus to="" from=""/>
+                  </finalRubric>
+                  <note>citing <persName ref="http://syriaca.org/person/430">Cyril of Alexandria</persName></note>
+                </msItem>
+                <msItem>
+                  <locus to="" from="48b"/>
+                  <author ref="http://syriaca.org/person/573">Chrysostom</author>
+                  <title ref="" xml:lang="en">Chrysostom on the <ref target="http://syriaca.org/work/9641">Gospel of S. John, chh. v. 19,
+                      31, viii. 56, x. 1, xiii. 32</ref></title>
+                  <rubric xml:lang="syr"/>
+                  <incipit xml:lang="syr"/>
+                  <quote xml:lang="syr">
+                    <locus from="" to=""/>
+                  </quote>
+                  <explicit xml:lang="syr">
+                    <locus to="" from=""/>
+                  </explicit>
+                  <finalRubric xml:lang="syr">
+                    <locus to="" from=""/>
+                  </finalRubric>
+                  <note/>
+                </msItem>
+              </msItem>
+              <msItem>
+                <locus to="" from="49b"/>
+                <author ref="http://syriaca.org/person/44">Philoxenus of Mabūg</author>
+                <title ref="" xml:lang="en">Extracts from the writings of Philoxenus of
+                  Mabūg</title>
+                <rubric xml:lang="syr"/>
+                <incipit xml:lang="syr"/>
+                <quote xml:lang="syr">
+                  <locus from="" to=""/>
+                </quote>
+                <explicit xml:lang="syr">
+                  <locus to="" from=""/>
+                </explicit>
+                <finalRubric xml:lang="syr">
+                  <locus to="" from=""/>
+                </finalRubric>
+                <note/>
+                <msItem>
+                  <locus to="" from="49b"/>
+                  <author ref="http://syriaca.org/person/44">Philoxenus of Mabūg</author>
+                  <title ref="" xml:lang="en">Part A</title>
+                  <rubric xml:lang="syr">ܡܢ ܪܝܫܐ ܕܠ܏ܗ ܕܠܘܩܒܠ ܢܣܛܘܪ̈ܝܢܘ. ܦܘܫܩܐ̣ ܕܗܠܝܢ ܕܣ̈ܝ̣ܡܢ ܡܢ
+                    ܠܬܚܬ. ܡܚܘܐ ܐܘܢܓܠܣܛܐ ܠܘܩܐ̣. ܕܐܝܠܝܢ ܗ̈ܘ̣ܝ ܡܢ ܡܫܝܚܐ̇. ܘܠܘܬܗ ܘܚܠܦܘܗܝ ܘܡܛܠܬܗ.
+                    ܏ܘܫ.</rubric>
+                  <incipit xml:lang="syr"/>
+                  <quote xml:lang="syr">
+                    <locus from="" to=""/>
+                  </quote>
+                  <explicit xml:lang="syr">
+                    <locus to="" from=""/>
+                  </explicit>
+                  <finalRubric xml:lang="syr">
+                    <locus to="" from=""/>
+                  </finalRubric>
+                  <note/>
+                </msItem>
+                <msItem>
+                  <locus to="" from="49b"/>
+                  <author ref="http://syriaca.org/person/44">Philoxenus of Mabūg</author>
+                  <title ref="" xml:lang="en">Part B</title>
+                  <rubric xml:lang="syr">ܬܘܒ ܕܝܠܗ ܩܕܡ ܗܠܝ̣ܢ. ܡܢ ܪܝܫܐ ܕ܏ܠܒ. ܦܘܫܩܐ̣ ܡܛܠ ܗܝ̇ ܕܐܬܝ̣ܠܕ
+                    ܡܪܢ ܒܡܥܪܬܐ ܘܐܬܬ̣ܣܝܡ ܒܐܘܪܝܐ..</rubric>
+                  <incipit xml:lang="syr"/>
+                  <quote xml:lang="syr">
+                    <locus from="" to=""/>
+                  </quote>
+                  <explicit xml:lang="syr">
+                    <locus to="" from=""/>
+                  </explicit>
+                  <finalRubric xml:lang="syr">
+                    <locus to="" from=""/>
+                  </finalRubric>
+                  <note/>
+                </msItem>
+                <msItem>
+                  <locus to="" from="49b"/>
+                  <author ref="http://syriaca.org/person/44">Philoxenus of Mabūg</author>
+                  <title ref="" xml:lang="en">Part C</title>
+                  <rubric xml:lang="syr">ܡܛܠ ܗܝ̇ ܕܐܬܬ̇ܥܪܩ ܡܫܝܚܐ ܠܡܨܪܝܢ</rubric>
+                  <incipit xml:lang="syr"/>
+                  <quote xml:lang="syr">
+                    <locus from="" to=""/>
+                  </quote>
+                  <explicit xml:lang="syr">
+                    <locus to="" from=""/>
+                  </explicit>
+                  <finalRubric xml:lang="syr">
+                    <locus to="" from=""/>
+                  </finalRubric>
+                  <note/>
+                </msItem>
+                <msItem>
+                  <locus to="" from="49b"/>
+                  <author ref="http://syriaca.org/person/44">Philoxenus of Mabūg</author>
+                  <title ref="" xml:lang="en">Part D</title>
+                  <rubric xml:lang="syr">ܬܘܒ ܕܝܠܗ ܡܢ ܪܝܫܐ ܕ܏ܘ܆ ܡܛܠ ܗܝ̇ ܕܟܡܐ ܙܒܢܐ ܗܘ̣ܐ ܡܫܝܚܐ
+                    ܒܡܨܪܝܢ.</rubric>
+                  <incipit xml:lang="syr"/>
+                  <quote xml:lang="syr">
+                    <locus from="" to=""/>
+                  </quote>
+                  <explicit xml:lang="syr">
+                    <locus to="" from=""/>
+                  </explicit>
+                  <finalRubric xml:lang="syr">
+                    <locus to="" from=""/>
+                  </finalRubric>
+                  <note/>
+                </msItem>
+                <msItem>
+                  <locus to="" from="49b"/>
+                  <author ref="http://syriaca.org/person/44">Philoxenus of Mabūg</author>
+                  <title ref="" xml:lang="en">Part E</title>
+                  <rubric xml:lang="syr">ܬܘܒ ܕܝܠܗ ܩܕܡ ܗܠܝ̣ܢ. ܡܢ ܪܝܫܐ ܕ܏ܗ. ܡܛܠ ܙܒܢܐ ܕܝܠܝܕܘܬܗ
+                    ܕܡܪܢ.</rubric>
+                  <incipit xml:lang="syr"/>
+                  <quote xml:lang="syr">
+                    <locus from="" to=""/>
+                  </quote>
+                  <explicit xml:lang="syr">
+                    <locus to="" from=""/>
+                  </explicit>
+                  <finalRubric xml:lang="syr">
+                    <locus to="" from=""/>
+                  </finalRubric>
+                  <note/>
+                </msItem>
+                <msItem>
+                  <locus to="" from="49b"/>
+                  <author ref="http://syriaca.org/person/44">Philoxenus of Mabūg</author>
+                  <title ref="" xml:lang="en">Part F</title>
+                  <rubric xml:lang="syr">ܕܝܠܗ ܟܕ ܕܝܠܗ̣ ܡܢ ܡ ܏ܕܚ ܕܠܘܩܒܠ ܚܒܝܒ ܗܪܛܝܩܐ ܡܛܠ ܗܠܝܢ ܕܣ̣ܝ̈ܡܢ.
+                    ܬܠܬܐ ܗܟܝܠ ܐܣ̈ܟܡܝܢ ܐܝܬ ܠܗ̇ ܠܠܘܛܬܐ ܒܟܬܒܐ ܐܠܗܝܐ. ܠܘܛܬܐ ܕܡܠܬܐ. ܠܘܛܬܐ ܕܚܛܝ̣ܬܐ. ܠܘܛܬܐ
+                    ܕܡܣܡ ܒܪܝܫܐ. ܏ܘܫ.</rubric>
+                  <incipit xml:lang="syr"/>
+                  <quote xml:lang="syr">
+                    <locus from="" to=""/>
+                  </quote>
+                  <explicit xml:lang="syr">
+                    <locus to="" from=""/>
+                  </explicit>
+                  <finalRubric xml:lang="syr">
+                    <locus to="" from=""/>
+                  </finalRubric>
+                  <note/>
+                </msItem>
+              </msItem>
+            </msItem>
+            <p>Severus</p>
+          </msContents>
+          <physDesc>
+            <objectDesc form="codex">
+              <supportDesc material="perg">
+                <extent>
+                  <measure unit="content_pending" quantity="-1"/>
+                </extent>
+                <foliation/>
+                <collation/>
+                <condition>
+                  <list>
+                    <item>
+                      <p>Vellum, about 9 7/8 in. by 6 5/8, consisting of 294 leaves, some of which
+                        are much stained and the last is mutilated. The quires, 30 in number, are
+                        signed with letters. There are from 27 to 41 lines in each page. Leaves are
+                        wanting after foll. 8 and 151. This manuscript seems to have been written by
+                        three hands, foll. 1—16 and foll. 28—79 b being in a good, though rather
+                        coarse, Estrangělā; foll. 79 b —294 in a finer Estrangělā; and foll. 17— 27
+                        in a more current hand. It belongs to the end of the viiith or beginning of
+                        the ixth cent. The contents are of a very miscellaneous character.</p>
+                    </item>
+                  </list>
+                </condition>
+              </supportDesc>
+              <layoutDesc>
+                <p>Content pending</p>
+              </layoutDesc>
+            </objectDesc>
+            <handDesc>
+              <handNote scope="" script="" medium="">
+                <desc/>
+              </handNote>
+            </handDesc>
+            <additions>
+              <p/>
+              <list>
+                <item>
+                  <locus from="" to=""/>
+                  <p/>
+                  <p><quote xml:lang="syr"/></p>
+                </item>
+              </list>
+            </additions>
+            <bindingDesc>
+              <p>Content pending</p>
+            </bindingDesc>
+            <sealDesc>
+              <p>Content pending</p>
+            </sealDesc>
+            <accMat/>
+          </physDesc>
+          <history>
+            <origin>
+              <origDate notBefore="0775" notAfter="0825" from="" to="" when="">the end of the viiith
+                or beginning of the ixth cent.</origDate>
+              <origPlace ref="" xml:lang=""/>
+            </origin>
+            <provenance/>
+            <acquisition/>
+          </history>
+          <additional/>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>Content pending</p>
+    </encodingDesc>
+    <profileDesc/>
+    <revisionDesc status="draft">
+      <change when="" who="http://syriaca.org/documentation/editors.xml#cchen">Initial TEI encoding.</change>
+      <change type="planned" subtype="consultation">Wright's description is so incomplete that the
+        physical manuscript needs to be consulted and redescribed.</change>
+      <change type="planned" subtype="checkSyriac">The Syriac copied from the Word Document needs to
+        be checked for accuracy: Part I, Authority #9 (Dioscorus of Alexandria) has mangled Syriac
+        due to square bracket notation, please add &lt;quote> as well</change>
+      <change type="planned" subtype="question">Question in Word Doc to be Addressed: Unsure of how
+        to format title for Section I and II; the note tags denote extra information not part of
+        implied title rather than footnotes</change>
+    </revisionDesc>
+  </teiHeader>
+  <facsimile>
+    <formula>Content pending</formula>
+  </facsimile>
+  <text>
+    <body>
+      <bibl>Content pending</bibl>
+    </body>
+  </text>
+</TEI>

--- a/data/3_drafts/ClaireChen/29B.xml
+++ b/data/3_drafts/ClaireChen/29B.xml
@@ -1,0 +1,953 @@
+<?xml version="1.0" encoding="utf-8"?>
+<?oxygen RNGSchema="https://raw.githubusercontent.com/wlpotter/syriaca-wright-catalog/master/schemas/enrich-syriaca.rnc" type="compact"?>
+<?xml-stylesheet type="text/css" href="https://raw.githubusercontent.com/srophe/wright-catalogue/master/parameters/wright-mss.css"?>
+<TEI xml:lang="en" xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader xmlns="http://www.tei-c.org/ns/1.0">
+    <fileDesc>
+      <titleStmt>
+        <title>Content pending</title>
+      </titleStmt>
+      <editionStmt>
+        <p>Content pending</p>
+      </editionStmt>
+      <publicationStmt>
+        <p>Content pending</p>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <idno type="URI">29</idno>
+            <altIdentifier>
+              <idno type="BL-Shelfmark">Add. 12,154</idno>
+            </altIdentifier>
+          </msIdentifier>
+          <msContents>
+            <summary/>
+            <textLang mainLang="syr"/>
+            <msItem>
+              <locus to="" from=""/>
+              <author ref=""/>
+              <title ref="" xml:lang="en"><note>A tract in defence of Monophysite doctrines</note>
+                Demonstrations, or Evidences, concerning the Dispensation of the Messiah <note>divided
+                  into fifteen chapters</note></title>
+              <rubric xml:lang="syr">$$$SEE 29A$$$</rubric>
+              <incipit xml:lang="syr"/>
+              <quote xml:lang="syr">$$$SEE 29A$$$<locus to=""/></quote>
+              <explicit xml:lang="syr">
+                <locus to="" from=""/>
+              </explicit>
+              <finalRubric xml:lang="syr">
+                <locus to="" from=""/>
+              </finalRubric>
+              <note>$$$SEE 29A$$$</note>
+              <msItem>
+                <locus to="" from="51b"/>
+                <author ref="http://syriaca.org/person/573">John Chrysostom</author>
+                <title ref="" xml:lang="en">Extracts from the commentaries of John
+                  Chrysostom</title>
+                <rubric xml:lang="syr"/>
+                <incipit xml:lang="syr"/>
+                <quote xml:lang="syr">
+                  <locus from="" to=""/>
+                </quote>
+                <explicit xml:lang="syr">
+                  <locus to="" from=""/>
+                </explicit>
+                <finalRubric xml:lang="syr">
+                  <locus to="" from=""/>
+                </finalRubric>
+                <note/>
+                <msItem>
+                  <locus to="" from="51b"/>
+                  <author ref="http://syriaca.org/person/573">John Chrysostom</author>
+                  <title ref="" xml:lang="en">On the <ref target="http://syriaca.org/work/9646">Gospel of S. Matthew, chh. xiii. 12, x.
+                    24, 29, 30, xxii. 11</ref> (<persName>Jacob of Batnae</persName> is referred
+                    to by the scribe), <ref target="http://syriaca.org/work/9646">xxv. 14</ref>, seqq. (<persName ref="http://syriaca.org/person/430">Cyril of
+                      Alexandria</persName>, hom. cxxviii. on the <ref target="http://syriaca.org/work/9648">Gospel of S. Luke</ref>, is
+                    referred to by the scribe).</title>
+                  <rubric xml:lang="syr"/>
+                  <incipit xml:lang="syr"/>
+                  <quote xml:lang="syr">
+                    <locus from="" to=""/>
+                  </quote>
+                  <explicit xml:lang="syr">
+                    <locus to="" from=""/>
+                  </explicit>
+                  <finalRubric xml:lang="syr">
+                    <locus to="" from=""/>
+                  </finalRubric>
+                  <note/>
+                </msItem>
+                <msItem>
+                  <locus to="" from="51b"/>
+                  <author ref="">Jacob of Batnae</author>
+                  <title ref="" xml:lang="en">Jacob of Batnae on <ref target="http://syriaca.org/work/9646">S. Matthew, ch. xxv. 14</ref>,
+                    seqq.</title>
+                  <rubric xml:lang="syr"/>
+                  <incipit xml:lang="syr"/>
+                  <quote xml:lang="syr">
+                    <locus from="" to=""/>
+                  </quote>
+                  <explicit xml:lang="syr">
+                    <locus to="" from=""/>
+                  </explicit>
+                  <finalRubric xml:lang="syr">
+                    <locus to="" from=""/>
+                  </finalRubric>
+                  <note/>
+                </msItem>
+                <msItem>
+                  <locus to="" from="51b"/>
+                  <author ref="http://syriaca.org/person/573">Chrysostom</author>
+                  <title ref="" xml:lang="en">Chrysostom on <ref target="http://syriaca.org/work/9597">Galat., ch. i. 4</ref>,
+                    <ref target="http://syriaca.org/work/9598">Ephes., ch. v. 16</ref>, <ref target="http://syriaca.org/work/9597">Galat., ch. v. 17</ref>; extract from hom. xviii. on the 
+                    <ref target="http://syriaca.org/work/9607">Epistle to the Hebrews</ref></title>
+                  <rubric xml:lang="syr">ܡܛܠ ܗܝ̇ ܕܐܡ̇ܪܝܢܢ ܩܘܕܫܐ ܠܩܕܝܫ̈ܐ</rubric>
+                  <incipit xml:lang="syr"/>
+                  <quote xml:lang="syr">
+                    <locus from="" to=""/>
+                  </quote>
+                  <explicit xml:lang="syr">
+                    <locus to="" from=""/>
+                  </explicit>
+                  <finalRubric xml:lang="syr">
+                    <locus to="" from=""/>
+                  </finalRubric>
+                  <note/>
+                </msItem>
+                <msItem>
+                  <locus to="" from="51b"/>
+                  <author ref="">Basil</author>
+                  <title ref="" xml:lang="en">Basil</title>
+                  <rubric xml:lang="syr">ܡܢ ܡܐܡܪܐ ܏ܕܒ ܥܠ ܫܬܬ ܝܘ̈ܡܐ. ܡܛܠ ܒܝ̣ܫ̈ܬܐ ܗܠܝܢ ܕܓ̈ܕܫܢ ܠܢ.
+                    ܒܬܠܬܐ ܗܟܝܠ ܙܢ̈ܝܐ ܐܡ̇ܪ ܕܗܘ̈ܝܢ ܒܝ̣ܫ̈ܬܐ. ܡܢ ܟܝܢܐ̇ ܘܡܢ ܘܡܢ ܨܒܝܢܐ ܕܚܐܪܘܬܐ. ܏ܘܫ.
+                    (αὐτομάτην). </rubric>
+                  <rubric xml:lang="syr">ܦܓܥ̣ܐ ܐܘ ܟܝܬ ܐܘܛܘܡܛܘܢ̣.</rubric>
+                  <incipit xml:lang="syr"/>
+                  <quote xml:lang="syr">
+                    <locus from="" to=""/>
+                  </quote>
+                  <explicit xml:lang="syr">
+                    <locus to="" from=""/>
+                  </explicit>
+                  <finalRubric xml:lang="syr">
+                    <locus to="" from=""/>
+                  </finalRubric>
+                  <note/>
+                </msItem>
+                <msItem>
+                  <locus to="" from="51b"/>
+                  <author ref="http://syriaca.org/person/573">Chrysostom</author>
+                  <title ref="" xml:lang="en">Chrysostom on <ref target="http://syriaca.org/work/9598">Ephes., ch. ii. 2</ref></title>
+                  <rubric xml:lang="syr"/>
+                  <incipit xml:lang="syr"/>
+                  <quote xml:lang="syr">
+                    <locus from="" to=""/>
+                  </quote>
+                  <explicit xml:lang="syr">
+                    <locus to="" from=""/>
+                  </explicit>
+                  <finalRubric xml:lang="syr">
+                    <locus to="" from=""/>
+                  </finalRubric>
+                  <note/>
+                </msItem>
+              </msItem>
+              <msItem>
+                <locus to="" from="55b"/>
+                <author ref="http://syriaca.org/person/13">Ephraim</author>
+                <title ref="" xml:lang="en">Extracts from Ephraim</title>
+                <rubric xml:lang="syr"/>
+                <incipit xml:lang="syr"/>
+                <quote xml:lang="syr">
+                  <locus from="" to=""/>
+                </quote>
+                <explicit xml:lang="syr">
+                  <locus to="" from=""/>
+                </explicit>
+                <finalRubric xml:lang="syr">
+                  <locus to="" from=""/>
+                </finalRubric>
+                <note/>
+                <msItem>
+                  <locus to="" from="55b"/>
+                  <author ref="http://syriaca.org/person/13">Ephraim</author>
+                  <title ref="" xml:lang="en">On <ref target="http://syriaca.org/work/9666">Joshua, ch. xx</ref>.</title>
+                  <rubric xml:lang="syr">ܡܢ ܡܕܪ̈ܫܐ ܕܥܠ ܗܝܡܢܘܬܐ̣ ܥܠ ܩܠܐ ܕܐܘ ܬܠܡܝܕܝ</rubric>
+                  <incipit xml:lang="syr"/>
+                  <quote xml:lang="syr">
+                    <locus from="" to=""/>
+                  </quote>
+                  <explicit xml:lang="syr">
+                    <locus to="" from=""/>
+                  </explicit>
+                  <finalRubric xml:lang="syr">
+                    <locus to="" from=""/>
+                  </finalRubric>
+                  <note/>
+                </msItem>
+                <msItem>
+                  <locus to="" from="55b"/>
+                  <author ref="http://syriaca.org/person/13">Ephraim</author>
+                  <title ref="" xml:lang="en">on <ref target="http://syriaca.org/work/9632">Exod., ch. xxxii. 20</ref></title>
+                  <rubric xml:lang="syr">ܡܢ ܡܐܡܪܐ ܕܐܡܝܪ ܠܗ ܥܠ ܒܝܬ ܕܢܚܗ ܕܡܪܢ̇ ܕܪܝܫܗ̣. ܛܝܒܘܬܐ ܩܪܒ̣ܬ
+                    ܠܦܘܡ̈ܐ ܕܡ̈ܓܕܦܢܐ</rubric>
+                  <incipit xml:lang="syr"/>
+                  <quote xml:lang="syr">
+                    <locus from="" to=""/>
+                  </quote>
+                  <explicit xml:lang="syr">
+                    <locus to="" from=""/>
+                  </explicit>
+                  <finalRubric xml:lang="syr">
+                    <locus to="" from=""/>
+                  </finalRubric>
+                  <note/>
+                </msItem>
+                <msItem>
+                  <locus to="" from="55b"/>
+                  <author ref="http://syriaca.org/person/13">Ephraim</author>
+                  <title ref="" xml:lang="en">on the three days during which our Lord lay in the
+                    grave</title>
+                  <rubric xml:lang="syr">ܡܢ ܡܕܪܫܐ ܕܥܠ ܙܩܝܦܘܬܐ ܒܩܠܐ ܕܟܠܬ ܡ̇ܠܟܐ</rubric>
+                  <incipit xml:lang="syr"/>
+                  <quote xml:lang="syr">
+                    <locus from="" to=""/>
+                  </quote>
+                  <explicit xml:lang="syr">
+                    <locus to="" from=""/>
+                  </explicit>
+                  <finalRubric xml:lang="syr">
+                    <locus to="" from=""/>
+                  </finalRubric>
+                  <note>to which is added an extract from the "<ref target="http://syriaca.org/bibl/175">Didascalia Apostolorum</ref>," <quote xml:lang="syr">ܕܝܕܣܩܠܝܐ ܕܫ̈ܠܝ̣ܚܐ</quote>, on the same subject, <locus>fol. 56 a</locus>.</note>
+                </msItem>
+              </msItem>
+              <msItem>
+                <locus to="" from="56a"/>
+                <author ref="http://syriaca.org/person/51">Severus of Antioch</author>
+                <title ref="" xml:lang="en">Extracts from the writings of Severus of Antioch</title>
+                <rubric xml:lang="syr"/>
+                <incipit xml:lang="syr"/>
+                <quote xml:lang="syr">
+                  <locus from="" to=""/>
+                </quote>
+                <explicit xml:lang="syr">
+                  <locus to="" from=""/>
+                </explicit>
+                <finalRubric xml:lang="syr">
+                  <locus to="" from=""/>
+                </finalRubric>
+                <note/>
+                <msItem>
+                  <locus to="" from="56a"/>
+                  <author ref="http://syriaca.org/person/51">Severus of Antioch</author>
+                  <title ref="" xml:lang="en">On the name ܢܘܗܪ̈ܐ (τὰ φῶτα), applied to the
+                    Epiphany</title>
+                  <rubric xml:lang="syr">ܡܢ ܡܐܡܪܐ ܏ܕܝ ܕܐܦܝܬܪܘܢܝܘܢ</rubric>
+                  <incipit xml:lang="syr"/>
+                  <quote xml:lang="syr">
+                    <locus from="" to=""/>
+                  </quote>
+                  <explicit xml:lang="syr">
+                    <locus to="" from=""/>
+                  </explicit>
+                  <finalRubric xml:lang="syr">
+                    <locus to="" from=""/>
+                  </finalRubric>
+                  <note/>
+                </msItem>
+                <msItem>
+                  <locus to="" from="56a"/>
+                  <author ref="http://syriaca.org/person/51">Severus of Antioch</author>
+                  <title ref="" xml:lang="en">on <ref target="http://syriaca.org/work/9646">S. Matthew, ch. xxvii. 46</ref></title>
+                  <rubric xml:lang="syr">ܡܢ ܡܐܡܪܐ ܕ܏ܟܒ </rubric>
+                  <incipit xml:lang="syr"/>
+                  <quote xml:lang="syr">
+                    <locus from="" to=""/>
+                  </quote>
+                  <explicit xml:lang="syr">
+                    <locus to="" from=""/>
+                  </explicit>
+                  <finalRubric xml:lang="syr">
+                    <locus to="" from=""/>
+                  </finalRubric>
+                  <note/>
+                </msItem>
+                <msItem>
+                  <locus to="" from="56a"/>
+                  <author ref="http://syriaca.org/person/51">Severus of Antioch</author>
+                  <title ref="" xml:lang="en">on <ref target="http://syriaca.org/work/9595">1st Corinth., ch. xv. 28</ref></title>
+                  <rubric xml:lang="syr">ܡܢ ܡܐܡܪܐ ܕ܏ܡܛ</rubric>
+                  <incipit xml:lang="syr"/>
+                  <quote xml:lang="syr">
+                    <locus from="" to=""/>
+                  </quote>
+                  <explicit xml:lang="syr">
+                    <locus to="" from=""/>
+                  </explicit>
+                  <finalRubric xml:lang="syr">
+                    <locus to="" from=""/>
+                  </finalRubric>
+                  <note/>
+                </msItem>
+                <msItem>
+                  <locus to="" from="56a"/>
+                  <author ref="http://syriaca.org/person/51">Severus of Antioch</author>
+                  <title ref="" xml:lang="en">on <ref target="http://syriaca.org/work/9646">S. Matthew, ch. xii. 32</ref></title>
+                  <rubric xml:lang="syr">ܡܢ ܡܐܡܪܐ ܕ܏ܨܚ</rubric>
+                  <incipit xml:lang="syr"/>
+                  <quote xml:lang="syr">
+                    <locus from="" to=""/>
+                  </quote>
+                  <explicit xml:lang="syr">
+                    <locus to="" from=""/>
+                  </explicit>
+                  <finalRubric xml:lang="syr">
+                    <locus to="" from=""/>
+                  </finalRubric>
+                  <note/>
+                </msItem>
+                <msItem>
+                  <locus to="" from="56a"/>
+                  <author ref="http://syriaca.org/person/51">Severus of Antioch</author>
+                  <title ref="" xml:lang="en">on <ref target="http://syriaca.org/work/9594">Rom., ch. iii. 28</ref>, and the <ref target="http://syriaca.org/work/9702">Epistle
+                      of S. James, ch. ii. 17</ref></title>
+                  <rubric xml:lang="syr">ܡܢ ܐܓܪܬܐ ܕ܏ܒ ܕܠܘܬ ܝܘܠܝܢܐ ܕܐܠܝܩܪܢܣܘܣ</rubric>
+                  <incipit xml:lang="syr"/>
+                  <quote xml:lang="syr">
+                    <locus from="" to=""/>
+                  </quote>
+                  <explicit xml:lang="syr">
+                    <locus to="" from=""/>
+                  </explicit>
+                  <finalRubric xml:lang="syr">
+                    <locus to="" from=""/>
+                  </finalRubric>
+                  <note/>
+                </msItem>
+                <msItem>
+                  <locus to="" from="56a"/>
+                  <author ref="http://syriaca.org/person/51">Severus of Antioch</author>
+                  <title ref="" xml:lang="en">on <ref target="http://syriaca.org/work/9646">S. Matthew, ch.xxiv. 19,20,28,41</ref></title>
+                  <rubric xml:lang="syr">ܡܢ ܐܓܪܬܐ ܕܠܘܬ ܐܢܣܛܣܝܐ ܡܫܡܫܢܝܬܐ</rubric>
+                  <incipit xml:lang="syr"/>
+                  <quote xml:lang="syr">
+                    <locus from="" to=""/>
+                  </quote>
+                  <explicit xml:lang="syr">
+                    <locus to="" from=""/>
+                  </explicit>
+                  <finalRubric xml:lang="syr">
+                    <locus to="" from=""/>
+                  </finalRubric>
+                  <note/>
+                </msItem>
+                <msItem>
+                  <locus to="" from="59a"/>
+                  <author ref="http://syriaca.org/person/51">Severus of Antioch</author>
+                  <title ref="" xml:lang="en">on <ref target="http://syriaca.org/work/9632">Exod., ch. xx. 25</ref></title>
+                  <rubric xml:lang="syr">ܡܢ ܐܓܪܬܐ ܕܠܘܬ ܩܘܣܛܢܛܝܢܐ ܐܦܝܣܩܘܦܐ ܕܠܕܝܩܝܐ</rubric>
+                  <incipit xml:lang="syr"/>
+                  <quote xml:lang="syr">
+                    <locus from="" to=""/>
+                  </quote>
+                  <explicit xml:lang="syr">
+                    <locus to="" from=""/>
+                  </explicit>
+                  <finalRubric xml:lang="syr">
+                    <locus to="" from=""/>
+                  </finalRubric>
+                  <note>citing <persName target="http://syriaca.org/person/430">Cyril of Alexandria</persName>, <quote xml:lang="syr">ܒܡܐܡܪܐ ܕ܏ܛ ܕܡܛܠ ܬܫܡܫܬܐ
+                    ܕܒܪܘܚ</quote>, <locus>fol. 59 a</locus>.</note>
+                </msItem>
+              </msItem>
+              <msItem>
+                <locus to="" from=""/>
+                <author ref=""/>
+                <title ref="" xml:lang="en">Miscellaneous extracts</title>
+                <rubric xml:lang="syr"/>
+                <incipit xml:lang="syr"/>
+                <quote xml:lang="syr">
+                  <locus from="" to=""/>
+                </quote>
+                <explicit xml:lang="syr">
+                  <locus to="" from=""/>
+                </explicit>
+                <finalRubric xml:lang="syr">
+                  <locus to="" from=""/>
+                </finalRubric>
+                <note/>
+                <msItem>
+                  <locus to="" from=""/>
+                  <author ref=""/>
+                  <title ref="" xml:lang="en">Part A</title>
+                  <rubric xml:lang="syr"/>
+                  <incipit xml:lang="syr"/>
+                  <quote xml:lang="syr">
+                    <locus from="" to=""/>
+                  </quote>
+                  <explicit xml:lang="syr">
+                    <locus to="" from=""/>
+                  </explicit>
+                  <finalRubric xml:lang="syr">
+                    <locus to="" from=""/>
+                  </finalRubric>
+                  <note/>
+                  <msItem>
+                    <locus to="" from="59a"/>
+                    <author ref="http://syriaca.org/person/430">Cyril of Alexandria</author>
+                    <title ref="" xml:lang="en">Cyril of Alexandria on <ref target="http://syriaca.org/work/9646">S. Matthew, ch. xv.
+                        5</ref></title>
+                    <rubric xml:lang="syr">ܡܢ ܡܐܡܪܐ ܕ܏ܝܘ ܕܥܠ ܬܫܡܫܬܐ ܕܪܘܚ</rubric>
+                    <incipit xml:lang="syr"/>
+                    <quote xml:lang="syr">
+                      <locus from="" to=""/>
+                    </quote>
+                    <explicit xml:lang="syr">
+                      <locus to="" from=""/>
+                    </explicit>
+                    <finalRubric xml:lang="syr">
+                      <locus to="" from=""/>
+                    </finalRubric>
+                    <note/>
+                  </msItem>
+                  <msItem>
+                    <locus to="" from="60a"/>
+                    <author ref="http://syriaca.org/person/430">Cyril of Alexandria</author>
+                    <title ref="" xml:lang="en">on <ref target="http://syriaca.org/work/9520">Levit., ch. xvi. 7</ref>, seqq.</title>
+                    <rubric xml:lang="syr">ܡܢ ܐܓܪܬܐ ܕܠܘܬ ܐܩܩ ܐ܏ܦܝܣ ܕܣܩܘܬܦܘܠܝܣ</rubric>
+                    <incipit xml:lang="syr"/>
+                    <quote xml:lang="syr">
+                      <locus from="" to=""/>
+                    </quote>
+                    <explicit xml:lang="syr">
+                      <locus to="" from=""/>
+                    </explicit>
+                    <finalRubric xml:lang="syr">
+                      <locus to="" from=""/>
+                    </finalRubric>
+                    <note/>
+                  </msItem>
+                  <msItem>
+                    <locus to="" from="60b"/>
+                    <author ref="http://syriaca.org/person/430">Cyril of Alexandria</author>
+                    <title ref="" xml:lang="en">on <ref target="http://syriaca.org/work/9520">Levit., ch. xiv. 4</ref>, seqq.</title>
+                    <rubric xml:lang="syr">ܡܢ ܣܟ̈ܘܠܝܐ</rubric>
+                    <rubric xml:lang="syr">ܡܢ ܡܢ ܡܐܡܪܐ ܕ܏ܝܐ. ܕܥܠ ܬܫܡܫܬܐ ܕܒܪܘܚ.</rubric>
+                    <incipit xml:lang="syr"/>
+                    <quote xml:lang="syr">
+                      <locus from="" to=""/>
+                    </quote>
+                    <explicit xml:lang="syr">
+                      <locus to="" from=""/>
+                    </explicit>
+                    <finalRubric xml:lang="syr">
+                      <locus to="" from=""/>
+                    </finalRubric>
+                    <note/>
+                  </msItem>
+                  <msItem>
+                    <locus to="" from="61a"/>
+                    <author ref="">Jacob of Batnae</author>
+                    <title ref="" xml:lang="en">Jacob of Batnae on the same passage</title>
+                    <rubric xml:lang="syr">ܡܢ ܡܐܡܪܗ ܕܥܠ ܗܠܝܢ ܬܪ̈ܬܝܢ ܨ̈ܦܪܐ.</rubric>
+                    <incipit xml:lang="syr"/>
+                    <quote xml:lang="syr">
+                      <locus from="" to=""/>
+                    </quote>
+                    <explicit xml:lang="syr">
+                      <locus to="" from=""/>
+                    </explicit>
+                    <finalRubric xml:lang="syr">
+                      <locus to="" from=""/>
+                    </finalRubric>
+                    <note/>
+                  </msItem>
+                </msItem>
+                <msItem>
+                  <locus to="" from=""/>
+                  <author ref=""/>
+                  <title ref="" xml:lang="en">Part B</title>
+                  <rubric xml:lang="syr"/>
+                  <incipit xml:lang="syr"/>
+                  <quote xml:lang="syr">
+                    <locus from="" to=""/>
+                  </quote>
+                  <explicit xml:lang="syr">
+                    <locus to="" from=""/>
+                  </explicit>
+                  <finalRubric xml:lang="syr">
+                    <locus to="" from=""/>
+                  </finalRubric>
+                  <note/>
+                  <msItem>
+                    <locus to="" from="62a"/>
+                    <author ref="http://syriaca.org/person/51">Severus of Antioch</author>
+                    <title ref="" xml:lang="en">Severus of Antioch on <ref target="http://syriaca.org/work/9672">Ps. cx. 1</ref></title>
+                    <rubric xml:lang="syr">ܡܢ ܩܦܠܐܘܢ ܕ܏ܠܓ ܕܡܐܡܪܐ ܕ܏ܓ ܕܠܘܩܒܠ ܓܪܡܛܝܩܘܣ</rubric>
+                    <incipit xml:lang="syr"/>
+                    <quote xml:lang="syr">
+                      <locus from="" to=""/>
+                    </quote>
+                    <explicit xml:lang="syr">
+                      <locus to="" from=""/>
+                    </explicit>
+                    <finalRubric xml:lang="syr">
+                      <locus to="" from=""/>
+                    </finalRubric>
+                    <note/>
+                  </msItem>
+                  <msItem>
+                    <locus to="" from="62b"/>
+                    <author ref="">Athanasius</author>
+                    <title ref="" xml:lang="en">Athanasius on the same</title>
+                    <rubric xml:lang="syr">ܡܢ ܡܐܡܪܐ ܩܕܡܝܐ ܕܠܘܩܒܠ ܐܪ̈ܝܐܢܘ</rubric>
+                    <incipit xml:lang="syr"/>
+                    <quote xml:lang="syr">
+                      <locus from="" to=""/>
+                    </quote>
+                    <explicit xml:lang="syr">
+                      <locus to="" from=""/>
+                    </explicit>
+                    <finalRubric xml:lang="syr">
+                      <locus to="" from=""/>
+                    </finalRubric>
+                    <note/>
+                  </msItem>
+                  <msItem>
+                    <locus to="" from="62b"/>
+                    <author ref="http://syriaca.org/person/573">Chrysostom</author>
+                    <title ref="" xml:lang="en">Chrysostom on the same</title>
+                    <rubric xml:lang="syr">ܡܢ ܡܐܡܪܐ ܕ܏ܒ ܕܦܘܫܩܐ ܕܐܓܪܬܐ ܕܠܘܬ ܥܒܪ̈ܝܐ.</rubric>
+                    <incipit xml:lang="syr"/>
+                    <quote xml:lang="syr">
+                      <locus from="" to=""/>
+                    </quote>
+                    <explicit xml:lang="syr">
+                      <locus to="" from=""/>
+                    </explicit>
+                    <finalRubric xml:lang="syr">
+                      <locus to="" from=""/>
+                    </finalRubric>
+                    <note/>
+                  </msItem>
+                  <msItem>
+                    <locus to="" from="63a"/>
+                    <author ref="http://syriaca.org/person/430">Cyril of Alexandria</author>
+                    <title ref="" xml:lang="en">Cyril of Alexandria on the same</title>
+                    <rubric xml:lang="syr">ܡܢ ܡܐܡܪܐ ܕ܏ܕ ܕܦܘܫܩܐ ܕܐܫܥܝܐ</rubric>
+                    <incipit xml:lang="syr"/>
+                    <quote xml:lang="syr">
+                      <locus from="" to=""/>
+                    </quote>
+                    <explicit xml:lang="syr">
+                      <locus to="" from=""/>
+                    </explicit>
+                    <finalRubric xml:lang="syr">
+                      <locus to="" from=""/>
+                    </finalRubric>
+                    <note/>
+                  </msItem>
+                </msItem>
+                <msItem>
+                  <locus to="" from=""/>
+                  <author ref=""/>
+                  <title ref="" xml:lang="en">Part C</title>
+                  <rubric xml:lang="syr"/>
+                  <incipit xml:lang="syr"/>
+                  <quote xml:lang="syr">
+                    <locus from="" to=""/>
+                  </quote>
+                  <explicit xml:lang="syr">
+                    <locus to="" from=""/>
+                  </explicit>
+                  <finalRubric xml:lang="syr">
+                    <locus to="" from=""/>
+                  </finalRubric>
+                  <note/>
+                  <msItem>
+                    <locus to="" from="63a"/>
+                    <author ref="http://syriaca.org/person/430">Cyril of Alexandria</author>
+                    <title ref="" xml:lang="en">Cyril of Alexandria on <ref target="http://syriaca.org/work/9646">S. Matthew, ch. xi.
+                        11</ref></title>
+                    <rubric xml:lang="syr">ܡܢ ܟܬܒܐ ܩܕܡܝܐ ܕܣܝܡܬܐ̣ ܡܢ ܏ܩܦ ܏ܕܝܐ</rubric>
+                    <incipit xml:lang="syr"/>
+                    <quote xml:lang="syr">
+                      <locus from="" to=""/>
+                    </quote>
+                    <explicit xml:lang="syr">
+                      <locus to="" from=""/>
+                    </explicit>
+                    <finalRubric xml:lang="syr">
+                      <locus to="" from=""/>
+                    </finalRubric>
+                    <note/>
+                  </msItem>
+                  <msItem>
+                    <locus to="" from="64a"/>
+                    <author ref="http://syriaca.org/person/44">Philoxenus of Mabūg</author>
+                    <title ref="" xml:lang="en">Philoxenus of Mabūg on the same</title>
+                    <rubric xml:lang="syr">ܡܢ ܦܘܫܩܐ ܕܡܬܝ ܐܘܢܓܠܣܛܐ</rubric>
+                    <incipit xml:lang="syr"/>
+                    <quote xml:lang="syr">
+                      <locus from="" to=""/>
+                    </quote>
+                    <explicit xml:lang="syr">
+                      <locus to="" from=""/>
+                    </explicit>
+                    <finalRubric xml:lang="syr">
+                      <locus to="" from=""/>
+                    </finalRubric>
+                    <note/>
+                  </msItem>
+                  <msItem>
+                    <locus to="" from="64b"/>
+                    <author ref="">Jacob of Batnae</author>
+                    <title ref="" xml:lang="en">Jacob of Batnae on the same</title>
+                    <rubric xml:lang="syr">ܡܢ ܡܐܡܪܐ ܕܥܠ ܗܕܐ</rubric>
+                    <incipit xml:lang="syr"/>
+                    <quote xml:lang="syr">
+                      <locus from="" to=""/>
+                    </quote>
+                    <explicit xml:lang="syr">
+                      <locus to="" from=""/>
+                    </explicit>
+                    <finalRubric xml:lang="syr">
+                      <locus to="" from=""/>
+                    </finalRubric>
+                    <note/>
+                  </msItem>
+                </msItem>
+                <msItem>
+                  <locus to="" from=""/>
+                  <author ref=""/>
+                  <title ref="" xml:lang="en">Part D</title>
+                  <rubric xml:lang="syr"/>
+                  <incipit xml:lang="syr"/>
+                  <quote xml:lang="syr">
+                    <locus from="" to=""/>
+                  </quote>
+                  <explicit xml:lang="syr">
+                    <locus to="" from=""/>
+                  </explicit>
+                  <finalRubric xml:lang="syr">
+                    <locus to="" from=""/>
+                  </finalRubric>
+                  <note/>
+                  <msItem>
+                    <locus to="" from="65a"/>
+                    <author ref="http://syriaca.org/person/430">Cyril of Alexandria</author>
+                    <title ref="" xml:lang="en">Cyril of Alexandria on <ref target="http://syriaca.org/work/9600">Coloss., ch. ii.
+                      9</ref></title>
+                    <rubric xml:lang="syr">ܡܢ ܡܐܡܪܐ ܕܠܘܬ ܡܠܟܬܐ</rubric>
+                    <rubric xml:lang="syr">ܡܢ ܐܓܪܬܐ ܏ܕܓ ܕܠܘܬ ܢܣܛܘܪܝܘܣ</rubric>
+                    <incipit xml:lang="syr"/>
+                    <quote xml:lang="syr">
+                      <locus from="" to=""/>
+                    </quote>
+                    <explicit xml:lang="syr">
+                      <locus to="" from=""/>
+                    </explicit>
+                    <finalRubric xml:lang="syr">
+                      <locus to="" from=""/>
+                    </finalRubric>
+                    <note/>
+                  </msItem>
+                </msItem>
+                <msItem>
+                  <locus to="" from=""/>
+                  <author ref=""/>
+                  <title ref="" xml:lang="en">Part E</title>
+                  <rubric xml:lang="syr"/>
+                  <incipit xml:lang="syr"/>
+                  <quote xml:lang="syr">
+                    <locus from="" to=""/>
+                  </quote>
+                  <explicit xml:lang="syr">
+                    <locus to="" from=""/>
+                  </explicit>
+                  <finalRubric xml:lang="syr">
+                    <locus to="" from=""/>
+                  </finalRubric>
+                  <note/>
+                  <msItem>
+                    <locus to="" from="65b"/>
+                    <author ref="http://syriaca.org/person/512">Gregory Nyssen</author>
+                    <title ref="" xml:lang="en">Gregory Nyssen on <ref target="http://syriaca.org/work/9594">Rom., ch. viii. 29</ref>,
+                      <ref target="http://syriaca.org/work/9600">Coloss., ch. i. 15, 18</ref>, and <ref target="http://syriaca.org/work/9607">Heb., ch. i. 6</ref></title>
+                    <rubric xml:lang="syr">ܡܢ ܡܐܡܪܐ ܕ܏ܒ ܕܠܘܩܒܠ ܐܢܘܡܝܘܣ</rubric>
+                    <incipit xml:lang="syr"/>
+                    <quote xml:lang="syr">
+                      <locus from="" to=""/>
+                    </quote>
+                    <explicit xml:lang="syr">
+                      <locus to="" from=""/>
+                    </explicit>
+                    <finalRubric xml:lang="syr">
+                      <locus to="" from=""/>
+                    </finalRubric>
+                    <note/>
+                  </msItem>
+                  <msItem>
+                    <locus to="" from="66a"/>
+                    <author ref="">Cyril</author>
+                    <title ref="" xml:lang="en">Cyril on the same</title>
+                    <rubric xml:lang="syr">ܡܢ ܏ܩܦܠ ܕ܏ܟܗ ܕܟܬܒܐ ܕܬܪܝܢ ܕܣܝܡܬܐ</rubric>
+                    <incipit xml:lang="syr"/>
+                    <quote xml:lang="syr">
+                      <locus from="" to=""/>
+                    </quote>
+                    <explicit xml:lang="syr">
+                      <locus to="" from=""/>
+                    </explicit>
+                    <finalRubric xml:lang="syr">
+                      <locus to="" from=""/>
+                    </finalRubric>
+                    <note/>
+                  </msItem>
+                </msItem>
+                <msItem>
+                  <locus to="" from=""/>
+                  <author ref=""/>
+                  <title ref="" xml:lang="en">Part F</title>
+                  <rubric xml:lang="syr"/>
+                  <incipit xml:lang="syr"/>
+                  <quote xml:lang="syr">
+                    <locus from="" to=""/>
+                  </quote>
+                  <explicit xml:lang="syr">
+                    <locus to="" from=""/>
+                  </explicit>
+                  <finalRubric xml:lang="syr">
+                    <locus to="" from=""/>
+                  </finalRubric>
+                  <note/>
+                  <msItem>
+                    <locus to="" from="66a"/>
+                    <author ref="">Athanasius</author>
+                    <title ref="" xml:lang="en">Athanasius on <ref target="http://syriaca.org/work/9595">lst Corinth., ch. xv.
+                      28</ref></title>
+                    <rubric xml:lang="syr">ܡܢ ܡܐܡܪܐ ܗ̇ܘ ܕܡܛܠ ܕܢܚ̣ܗ ܕܒܒܣܪ ܕܐܠܗܐ ܡܠܬܐ</rubric>
+                    <incipit xml:lang="syr"/>
+                    <quote xml:lang="syr">
+                      <locus from="" to=""/>
+                    </quote>
+                    <explicit xml:lang="syr">
+                      <locus to="" from=""/>
+                    </explicit>
+                    <finalRubric xml:lang="syr">
+                      <locus to="" from=""/>
+                    </finalRubric>
+                    <note/>
+                  </msItem>
+                  <msItem>
+                    <locus to="" from="66b"/>
+                    <author ref="">Severus</author>
+                    <title ref="" xml:lang="en">Severus on the same</title>
+                    <rubric xml:lang="syr"> ܡܢ ܏ܩܦ ܕ܏ܠܓ ܕܡܐܡܪܐ ܕ܏ܓ ܕܠܘܩܒܠ ܓܪܡܛܝܩܘܣ</rubric>
+                    <incipit xml:lang="syr"/>
+                    <quote xml:lang="syr">
+                      <locus from="" to=""/>
+                    </quote>
+                    <explicit xml:lang="syr">
+                      <locus to="" from=""/>
+                    </explicit>
+                    <finalRubric xml:lang="syr">
+                      <locus to="" from=""/>
+                    </finalRubric>
+                    <note>with a reference by the scribe to <persName ref="http://syriaca.org/person/511">Gregory Theologus</persName>,
+                      <quote xml:lang="syr">ܒܡܐܡܪܐ ܕܬܪܝܢ ܕܥܠ ܒܪܐ</quote></note>
+                  </msItem>
+                </msItem>
+                <msItem>
+                  <locus to="" from=""/>
+                  <author ref=""/>
+                  <title ref="" xml:lang="en">Part G</title>
+                  <rubric xml:lang="syr"/>
+                  <incipit xml:lang="syr"/>
+                  <quote xml:lang="syr">
+                    <locus from="" to=""/>
+                  </quote>
+                  <explicit xml:lang="syr">
+                    <locus to="" from=""/>
+                  </explicit>
+                  <finalRubric xml:lang="syr">
+                    <locus to="" from=""/>
+                  </finalRubric>
+                  <note/>
+                  <msItem>
+                    <locus to="" from=""/>
+                    <author ref="http://syriaca.org/person/573">Chrysostom</author>
+                    <title ref="66b" xml:lang="en">Chrysostom on the <ref
+                        target="http://syriaca.org/work/9641">Gospel of S. John, ch. ii.
+                      4</ref></title>
+                    <rubric xml:lang="syr">ܡܢ ܡܐܡܪܐ ܕ܏ܟܒ ܕܦܘܫܩܐ ܕܐܘܢܓܠܝܘܢ ܕܝܘܚܢܢ</rubric>
+                    <incipit xml:lang="syr"/>
+                    <quote xml:lang="syr">
+                      <locus from="" to=""/>
+                    </quote>
+                    <explicit xml:lang="syr">
+                      <locus to="" from=""/>
+                    </explicit>
+                    <finalRubric xml:lang="syr">
+                      <locus to="" from=""/>
+                    </finalRubric>
+                    <note/>
+                  </msItem>
+                  <msItem>
+                    <locus to="" from="67b"/>
+                    <author ref="">Severus</author>
+                    <title ref="" xml:lang="en">Severus on <ref target="http://syriaca.org/work/9641">S. John, ch. vii. 30</ref></title>
+                    <rubric xml:lang="syr">ܡܢ ܡܐܡܪܐ ܕ܏ܡܘ ܕܐܦܝܬܪܘܢܝܘܢ</rubric>
+                    <incipit xml:lang="syr"/>
+                    <quote xml:lang="syr">
+                      <locus from="" to=""/>
+                    </quote>
+                    <explicit xml:lang="syr">
+                      <locus to="" from=""/>
+                    </explicit>
+                    <finalRubric xml:lang="syr">
+                      <locus to="" from=""/>
+                    </finalRubric>
+                    <note/>
+                  </msItem>
+                </msItem>
+                <msItem>
+                  <locus to="" from=""/>
+                  <author ref=""/>
+                  <title ref="" xml:lang="en">Part H</title>
+                  <rubric xml:lang="syr"/>
+                  <incipit xml:lang="syr"/>
+                  <quote xml:lang="syr">
+                    <locus from="" to=""/>
+                  </quote>
+                  <explicit xml:lang="syr">
+                    <locus to="" from=""/>
+                  </explicit>
+                  <finalRubric xml:lang="syr">
+                    <locus to="" from=""/>
+                  </finalRubric>
+                  <note/>
+                  <msItem>
+                    <locus to="" from="68a"/>
+                    <author ref="">Athanasius</author>
+                    <title ref="" xml:lang="en">Athanasius on <ref target="http://syriaca.org/work/9647">S. Mark, ch. xiii.
+                      32</ref></title>
+                    <rubric xml:lang="syr">ܡܢ ܡܐܡܪܐ ܗ̇ܘ ܕܥܠ ܕܢܚ̣ܗ ܕܒܒܣܪ ܕܐܠܗܐ ܡܠܬܐ</rubric>
+                    <rubric xml:lang="syr">ܡܢ ܡܐܡܐ ܕ܏ܓ ܕܠܘܩܒܠ ܐܪ̈ܝܐܢܘ </rubric>
+                    <incipit xml:lang="syr"/>
+                    <quote xml:lang="syr">
+                      <locus from="" to=""/>
+                    </quote>
+                    <explicit xml:lang="syr">
+                      <locus to="" from=""/>
+                    </explicit>
+                    <finalRubric xml:lang="syr">
+                      <locus to="" from=""/>
+                    </finalRubric>
+                    <note/>
+                  </msItem>
+                  <msItem>
+                    <locus to="" from="68b"/>
+                    <author ref="">Basil</author>
+                    <title ref="" xml:lang="en">Basil on the same</title>
+                    <rubric xml:lang="syr">ܡܢ ܐܓܪܬܐ ܕܠܘܬ ܐܡܦܝܠܟܝܘܣ. ܗܝ̇ ܕܐܝܬܗܘܝ ܪܝܫܗ̣̇. ܐܬܒ̣ܥܝ ܡܢ
+                      ܟܕܘ ܨܝܕ ܣ̈ܓܝܐܐ.</rubric>
+                    <incipit xml:lang="syr"/>
+                    <quote xml:lang="syr">
+                      <locus from="" to=""/>
+                    </quote>
+                    <explicit xml:lang="syr">
+                      <locus to="" from=""/>
+                    </explicit>
+                    <finalRubric xml:lang="syr">
+                      <locus to="" from=""/>
+                    </finalRubric>
+                    <note/>
+                  </msItem>
+                </msItem>
+              </msItem>
+            </msItem>
+          </msContents>
+          <physDesc>
+            <objectDesc form="codex">
+              <supportDesc material="perg">
+                <extent>
+                  <measure unit="content_pending" quantity="-1"/>
+                </extent>
+                <foliation/>
+                <collation/>
+                <condition>
+                  <list>
+                    <item>
+                      <p>Vellum, about 9 7/8 in. by 6 5/8, consisting of 294 leaves, some of which
+                        are much stained and the last is mutilated. The quires, 30 in number, are
+                        signed with letters. There are from 27 to 41 lines in each page. Leaves are
+                        wanting after foll. 8 and 151. This manuscript seems to have been written by
+                        three hands, foll. 1—16 and foll. 28—79 b being in a good, though rather
+                        coarse, Estrangělā; foll. 79 b —294 in a finer Estrangělā; and foll. 17— 27
+                        in a more current hand. It belongs to the end of the viiith or beginning of
+                        the ixth cent. The contents are of a very miscellaneous character.</p>
+                    </item>
+                  </list>
+                </condition>
+              </supportDesc>
+              <layoutDesc>
+                <p>Content pending</p>
+              </layoutDesc>
+            </objectDesc>
+            <handDesc>
+              <handNote scope="" script=""
+                medium="">
+                <desc></desc>
+              </handNote>
+            </handDesc>
+            <additions>
+              <p></p>
+              <list>
+                <item>
+                  <locus from="" to=""/>
+                  <p></p>
+                  <p><quote xml:lang="syr"></quote></p>
+                </item>
+              </list>
+            </additions>
+            <bindingDesc>
+              <p>Content pending</p>
+            </bindingDesc>
+            <sealDesc>
+              <p>Content pending</p>
+            </sealDesc>
+            <accMat/>
+          </physDesc>
+          <history>
+            <origin>
+              <origDate notBefore="0775" notAfter="0825" from="" to="" when="">the end of the viiith
+                or beginning of the ixth cent.</origDate>
+              <origPlace ref="" xml:lang=""></origPlace>
+            </origin>
+            <provenance/>
+            <acquisition/>
+          </history>
+          <additional/>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>Content pending</p>
+    </encodingDesc>
+    <profileDesc/>
+    <revisionDesc status="draft">
+      <change when="" who="http://syriaca.org/documentation/editors.xml#cchen">Initial TEI encoding.</change>
+    </revisionDesc>
+  </teiHeader>
+  <facsimile>
+    <formula>Content pending</formula>
+  </facsimile>
+  <text>
+    <body>
+      <bibl>Content pending</bibl>
+    </body>
+  </text>
+</TEI>

--- a/data/3_drafts/ClaireChen/29C.xml
+++ b/data/3_drafts/ClaireChen/29C.xml
@@ -1,0 +1,961 @@
+<?xml version="1.0" encoding="utf-8"?>
+<?oxygen RNGSchema="https://raw.githubusercontent.com/wlpotter/syriaca-wright-catalog/master/schemas/enrich-syriaca.rnc" type="compact"?>
+<?xml-stylesheet type="text/css" href="https://raw.githubusercontent.com/srophe/wright-catalogue/master/parameters/wright-mss.css"?>
+<TEI xml:lang="en" xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader xmlns="http://www.tei-c.org/ns/1.0">
+    <fileDesc>
+      <titleStmt>
+        <title>Content pending</title>
+      </titleStmt>
+      <editionStmt>
+        <p>Content pending</p>
+      </editionStmt>
+      <publicationStmt>
+        <p>Content pending</p>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <idno type="URI">29</idno>
+            <altIdentifier>
+              <idno type="BL-Shelfmark">Add. 12,154</idno>
+            </altIdentifier>
+          </msIdentifier>
+          <msContents>
+            <summary/>
+            <textLang mainLang="syr"/>
+            <msItem>
+              <locus to="" from=""/>
+              <author ref=""/>
+              <title ref="" xml:lang="en"><note>A tract in defence of Monophysite doctrines</note>
+                Demonstrations, or Evidences, concerning the Dispensation of the Messiah <note>divided
+                  into fifteen chapters</note></title>
+              <rubric xml:lang="syr">$$$SEE 29A$$$</rubric>
+              <incipit xml:lang="syr"/>
+              <quote xml:lang="syr">$$$SEE 29A$$$<locus from="" to=""/></quote>
+              <explicit xml:lang="syr">
+                <locus to="" from=""/>
+              </explicit>
+              <finalRubric xml:lang="syr">
+                <locus to="" from=""/>
+              </finalRubric>
+              <note>$$$SEE 29A$$$</note>
+              <msItem>
+                <locus to="" from="69a"/>
+                <author ref="http://syriaca.org/person/573">Chrysostom</author>
+                <title ref="" xml:lang="en">Extracts from the homilies of Chrysostom on the
+                  <ref target="http://syriaca.org/work/9594">Epistle to the Romans</ref></title>
+                <rubric xml:lang="syr"/>
+                <incipit xml:lang="syr"/>
+                <quote xml:lang="syr">
+                  <locus from="" to=""/>
+                </quote>
+                <explicit xml:lang="syr">
+                  <locus to="" from=""/>
+                </explicit>
+                <finalRubric xml:lang="syr">
+                  <locus to="" from=""/>
+                </finalRubric>
+                <note/>
+                <msItem>
+                  <locus to="" from="83a"/>
+                  <author ref="http://syriaca.org/person/573">Chrysostom</author>
+                  <title ref="" xml:lang="en">
+                    <ref target="http://syriaca.org/work/9595">1st Corinthians</ref>
+                  </title>
+                  <rubric xml:lang="syr"/>
+                  <incipit xml:lang="syr"/>
+                  <quote xml:lang="syr">
+                    <locus from="" to=""/>
+                  </quote>
+                  <explicit xml:lang="syr">
+                    <locus to="" from=""/>
+                  </explicit>
+                  <finalRubric xml:lang="syr">
+                    <locus to="" from=""/>
+                  </finalRubric>
+                  <note/>
+                </msItem>
+                <msItem>
+                  <locus to="" from="96b"/>
+                  <author ref="http://syriaca.org/person/573">Chrysostom</author>
+                  <title ref="" xml:lang="en">
+                    <ref target="http://syriaca.org/work/9596">2nd Corinthians</ref>
+                  </title>
+                  <rubric xml:lang="syr"/>
+                  <incipit xml:lang="syr"/>
+                  <quote xml:lang="syr">
+                    <locus from="" to=""/>
+                  </quote>
+                  <explicit xml:lang="syr">
+                    <locus to="" from=""/>
+                  </explicit>
+                  <finalRubric xml:lang="syr">
+                    <locus to="" from=""/>
+                  </finalRubric>
+                  <note/>
+                </msItem>
+                <msItem>
+                  <locus to="" from="101b"/>
+                  <author ref="http://syriaca.org/person/573">Chrysostom</author>
+                  <title ref="" xml:lang="en">
+                    <ref target="http://syriaca.org/work/9597">Galatians</ref>
+                  </title>
+                  <rubric xml:lang="syr"/>
+                  <incipit xml:lang="syr"/>
+                  <quote xml:lang="syr">
+                    <locus from="" to=""/>
+                  </quote>
+                  <explicit xml:lang="syr">
+                    <locus to="" from=""/>
+                  </explicit>
+                  <finalRubric xml:lang="syr">
+                    <locus to="" from=""/>
+                  </finalRubric>
+                  <note/>
+                </msItem>
+                <msItem>
+                  <locus to="" from="105a"/>
+                  <author ref="http://syriaca.org/person/573">Chrysostom</author>
+                  <title ref="" xml:lang="en">
+                    <ref target="http://syriaca.org/work/9599">Philippians</ref>
+                  </title>
+                  <rubric xml:lang="syr"/>
+                  <incipit xml:lang="syr"/>
+                  <quote xml:lang="syr">
+                    <locus from="" to=""/>
+                  </quote>
+                  <explicit xml:lang="syr">
+                    <locus to="" from=""/>
+                  </explicit>
+                  <finalRubric xml:lang="syr">
+                    <locus to="" from=""/>
+                  </finalRubric>
+                  <note/>
+                </msItem>
+                <msItem>
+                  <locus to="" from="100a"/>
+                  <author ref="http://syriaca.org/person/573">Chrysostom</author>
+                  <title ref="" xml:lang="en">
+                    <ref target="http://syriaca.org/work/9600">Colossians</ref>
+                  </title>
+                  <rubric xml:lang="syr"/>
+                  <incipit xml:lang="syr"/>
+                  <quote xml:lang="syr">
+                    <locus from="" to=""/>
+                  </quote>
+                  <explicit xml:lang="syr">
+                    <locus to="" from=""/>
+                  </explicit>
+                  <finalRubric xml:lang="syr">
+                    <locus to="" from=""/>
+                  </finalRubric>
+                  <note/>
+                </msItem>
+                <msItem>
+                  <locus to="" from="106b"/>
+                  <author ref="http://syriaca.org/person/573">Chrysostom</author>
+                  <title ref="" xml:lang="en">
+                    <ref target="http://syriaca.org/work/9602">2nd Thessalonians</ref>
+                  </title>
+                  <rubric xml:lang="syr"/>
+                  <incipit xml:lang="syr"/>
+                  <quote xml:lang="syr">
+                    <locus from="" to=""/>
+                  </quote>
+                  <explicit xml:lang="syr">
+                    <locus to="" from=""/>
+                  </explicit>
+                  <finalRubric xml:lang="syr">
+                    <locus to="" from=""/>
+                  </finalRubric>
+                  <note/>
+                </msItem>
+                <msItem>
+                  <locus to="" from="107a"/>
+                  <author ref="http://syriaca.org/person/573">Chrysostom</author>
+                  <title ref="" xml:lang="en">
+                    <ref target="http://syriaca.org/work/9603">lst Timothy</ref>
+                  </title>
+                  <rubric xml:lang="syr"/>
+                  <incipit xml:lang="syr"/>
+                  <quote xml:lang="syr">
+                    <locus from="" to=""/>
+                  </quote>
+                  <explicit xml:lang="syr">
+                    <locus to="" from=""/>
+                  </explicit>
+                  <finalRubric xml:lang="syr">
+                    <locus to="" from=""/>
+                  </finalRubric>
+                  <note/>
+                </msItem>
+                <msItem>
+                  <locus to="" from="107b"/>
+                  <author ref="http://syriaca.org/person/573">Chrysostom</author>
+                  <title ref="" xml:lang="en">
+                    <ref target="http://syriaca.org/work/9607">Hebrews</ref>
+                  </title>
+                  <rubric xml:lang="syr"/>
+                  <incipit xml:lang="syr"/>
+                  <quote xml:lang="syr">
+                    <locus from="" to=""/>
+                  </quote>
+                  <explicit xml:lang="syr">
+                    <locus to="" from=""/>
+                  </explicit>
+                  <finalRubric xml:lang="syr">
+                    <locus to="" from=""/>
+                  </finalRubric>
+                  <note/>
+                </msItem>
+                <msItem>
+                  <locus to="" from="110b"/>
+                  <author ref="http://syriaca.org/person/573">Chrysostom</author>
+                  <title ref="" xml:lang="en">Extract from a discourse of Chrysostom on <ref target="http://syriaca.org/work/9603">1st
+                      Timothy, ch. v. 23</ref></title>
+                  <rubric xml:lang="syr">ܥܠ ܗ̇ܝ ܕܟܡܐ ܐܝܬܝܗܝܢ ܥ̈ܠܠ̣ܬܐ ܕܡܛܠܬܗܝܢ ܫ̇ܒܩ ܐܠܗܐ ܕܢܐܬܘܢ
+                    ܐܘ̈ܠܨܢܐ ܘܢܣ̈ܝܘܢܐ ܥܠ ܐܢܫ̈ܐ ܩܕܝܫ̈ܐ</rubric>
+                  <incipit xml:lang="syr"/>
+                  <quote xml:lang="syr">
+                    <locus from="" to=""/>
+                  </quote>
+                  <explicit xml:lang="syr">
+                    <locus to="" from=""/>
+                  </explicit>
+                  <finalRubric xml:lang="syr">
+                    <locus to="" from=""/>
+                  </finalRubric>
+                  <note/>
+                </msItem>
+                <msItem>
+                  <locus to="" from="111b"/>
+                  <author ref="http://syriaca.org/person/573">Chrysostom</author>
+                  <title ref="" xml:lang="en">Extract from another discourse of his</title>
+                  <rubric xml:lang="syr">ܥܠ ܗ̇ܝ ܕܟܡܐ ܐܝܬܝܗܝܢ ܥ̈ܠ̣ܠܬܐ ܕܡܦܩܬܗ ܕܐܕܡ ܡܢ ܦܪܕܝܣܐ.</rubric>
+                  <incipit xml:lang="syr"/>
+                  <quote xml:lang="syr">
+                    <locus from="" to=""/>
+                  </quote>
+                  <explicit xml:lang="syr">
+                    <locus to="" from=""/>
+                  </explicit>
+                  <finalRubric xml:lang="syr">
+                    <locus to="" from=""/>
+                  </finalRubric>
+                  <note/>
+                </msItem>
+              </msItem>
+              <msItem>
+                <locus to="" from="112a"/>
+                <author ref="http://syriaca.org/person/430">Cyril of Alexandria</author>
+                <title ref="" xml:lang="en">A series of extracts from the homilies of Cyril of
+                  Alexandria on the <ref target="http://syriaca.org/work/9648">Gospel of S. Luke</ref></title>
+                <rubric xml:lang="syr"/>
+                <incipit xml:lang="syr"/>
+                <quote xml:lang="syr">
+                  <locus from="" to=""/>
+                </quote>
+                <explicit xml:lang="syr">
+                  <locus to="" from=""/>
+                </explicit>
+                <finalRubric xml:lang="syr">
+                  <locus to="" from=""/>
+                </finalRubric>
+                <note/>
+              </msItem>
+              <msItem>
+                <locus to="" from="132b"/>
+                <author ref="">Jacob of Batnae</author>
+                <title ref="" xml:lang="en">A series of extracts from Jacob of Batnae</title>
+                <rubric xml:lang="syr"/>
+                <incipit xml:lang="syr"/>
+                <quote xml:lang="syr">
+                  <locus from="" to=""/>
+                </quote>
+                <explicit xml:lang="syr">
+                  <locus to="" from=""/>
+                </explicit>
+                <finalRubric xml:lang="syr">
+                  <locus to="" from=""/>
+                </finalRubric>
+                <note>They are taken from the discourses on <placeName>Sodom</placeName>, on
+                    <persName>Balaam</persName>, on the two goats and Azazel, on
+                    <persName>Samson</persName>, on the capture of the ark by the Philistines, on
+                    <persName>Elisha</persName>, on the chariot seen by
+                  <persName>Ezekiel</persName>, on the waters seen by <persName>Ezekiel</persName>
+                    (<ref target="http://syriaca.org/work/9621">ch. xlvii.</ref>), against the Jews,
+                  on <ref target="http://syriaca.org/work/9646">S. Matthew, ch. xiii. 33</ref>, on
+                    <ref target="http://syriaca.org/work/9646">S. Matthew, ch. xxi. 33</ref>, seqq.,
+                  on <ref target="http://syriaca.org/work/9646">S. Matthew, ch. xx. 1</ref>, seqq.,
+                  on the ten Virgins, on <ref target="http://syriaca.org/work/9646">S. Matthew, ch.
+                    xiii. 47</ref>, seqq., on <ref target="http://syriaca.org/work/9648">S. Luke,
+                    ch. vii. 37</ref>, on <ref target="http://syriaca.org/work/9646">S. Matthew, ch.
+                    xxii. 2</ref>, seqq., on <ref target="http://syriaca.org/work/9648">S. Luke, ch.
+                    x. 30</ref>, seqq., on <ref target="http://syriaca.org/work/9646">S. Matthew,
+                    ch. xi. 3</ref>, on the Crucifixion; from a letter to Jacob, abbat of the
+                  convent of Naphshāthā, <quote xml:lang="syr">ܦܘܫܩܐ̣ ܕܡ̈ܠܐ ܕܝܘܚܢܢ ܐܘܢܓܠܣܛܐ ܗܠܝܢ
+                    ܕܣܝ̈ܡܢ. ܐܢ ܐܢܫ ܢܚ̣ܛܐ ܚܛܗܐ ܕܡܘܬܐ̣. ܥܠ ܗܢܐ̣ ܠܐ ܐܢܫ ܢܒܥܐ</quote>; from a letter to
+                    <persName>Maro (ܡܪܘܢ) the monk</persName>, <quote xml:lang="syr">ܦܘܫܩܐ̣ ܡܛܠ ܓܘܕܦܐ ܕܥܠ ܪܘܚܐ
+                      ܩܕܝܫܐ.</quote>; and from a letter to <persName>Paul the monk</persName>. Interspersed with these are
+                  two extracts from <persName>Severus</persName>, the one on <ref target="http://syriaca.org/work/9648">S. Luke, ch. vii. 40</ref>, <quote xml:lang="syr">ܡܢ ܡ܏ܐܡ ܏ܕܩܝܚ ܕ܏ܐܦܝܬ</quote>,
+                  <locus>fol. 138 b</locus>; the other on <ref target="http://syriaca.org/work/9648">S. Luke, ch. x. 30</ref>, seqq., <locus>fol. 139 b</locus>; and a reference by
+                  the scribe to Chrysostom, <locus>fol. 141 a</locus>.</note>
+              </msItem>
+              <msItem>
+                <locus to="" from="141b"/>
+                <author ref="">Theodosius of Alexandria</author>
+                <author ref="">Empress Theodora</author>
+                <title ref="" xml:lang="en">Copious extracts from the discourse of Theodosius of
+                  Alexandria, addressed to the empress Theodora</title>
+                <rubric xml:lang="syr">ܥܠ ܗ̇ܝ ܕܒܬܠܬܐ ܙ̈ܢܝܐ ܒܝܬܝ ܠܗ ܡܫܝܚܐ ܐܠܗܢ ܠܚ̈ܫܐ ܐܢܫ̈ܝܐ ܕܝܠܢ̇. ܥܡ
+                  ܦܓܪܐ ܡܢܦܫܐ ܗ̇ܘ ܕܝܠܗ܀ ܕܩܕܝܫܐ ܐܬܘܕܘܣܝܘܣ ܦܦܐ ܕܐܠ܏ܟܣ̣. ܡܢ ܡܐܡܪܐ ܕܠܘܬ ܬܐܘܕܘܪܐ ܡ̇ܠܟܬܐ̇.
+                  ܗ̇ܘ ܕܡܛܠ ܗ̇ܢܘܢ ܕܐܡܪܝܢ ܕܠܐ ܝ̇ܕܥ ܗܘܐ ܡܫܝܚܐ ܠܝܘܡܐ ܗ̇ܘ ܐܚܪܝܐ.</rubric>
+                <incipit xml:lang="syr"/>
+                <quote xml:lang="syr">
+                  <locus from="" to=""/>
+                </quote>
+                <explicit xml:lang="syr">
+                  <locus to="" from=""/>
+                </explicit>
+                <finalRubric xml:lang="syr">
+                  <locus to="" from=""/>
+                </finalRubric>
+                <note>He cites <persName ref="http://syriaca.org/person/513">Gregory Thaumaturgus</persName>, <quote xml:lang="syr">ܒܡܐܡܪܐ ܗ̇ܘ ܕܡܛܠ
+                    ܡܬܒܣܪܢܘܬܐ</quote>, <locus>fol. 144 a</locus>; <persName>Athanasius</persName>,
+                    <quote xml:lang="syr">ܒܡܐܡܪܐ ܗ̇ܘ ܕܡܛܠ ܗܝܡܢܘܬܐ</quote>, <locus>fol. 144 b</locus>;
+                    <persName>Timotheus of Alexandria</persName>, <quote xml:lang="syr">ܒܣܝ̇ܡܐ ܗ̇ܘ ܕܐܬܬܣܝܡ ܡܢܗ
+                    ܠܘܩܒܠ ܬܚܘܡܐ ܕܗ̇ܢܘܢ ܕܐܬܟܢܫܘ ܐܟܚܕܐ ܒܣܘܢܘܕܘܣ ܕܟܠܩܝܕܘܢܐ</quote>, <locus>fol. 146
+                      a</locus>; <persName ref="http://syriaca.org/person/511">Gregory Nazianzen</persName>, <quote xml:lang="syr">ܒܡܐܡܪܐ ܗ̇ܘ ܕܬܪܝܢ ܕܡܛܠ
+                        ܒܪܐ</quote>, <locus>fol. 149 b</locus>; and <persName ref="http://syriaca.org/person/430">Cyril of
+                    Alexandria</persName>, <quote xml:lang="syr">ܒܟܬܒܐ ܕܥܣܪܐ ܕܡܥܗܕܢܘܬܐ ܕܐܘܢܓܠܝܘܢ ܕܡܬܝ</quote>,
+                    <locus>fol. 144 b</locus>, <quote xml:lang="syr">ܒܟܬܒܐ ܕܫܬܐ ܕܦܪܓܡܛܝܐ ܕܝܠܗ ܡܠܝܠܬܐ ܗܝ̇ ܕܠܘܬ
+                    ܐܪܡܝܐ</quote>, <locus>fol. 146 b</locus>, <quote xml:lang="syr">ܒܡܬܥܗܕܢܘܬܐ ܗܝ̇ ܕܐܫܥܝܐ</quote>,
+                    <locus>fol. 147 a</locus>, <quote xml:lang="syr">ܒܣܟܘܠܝܘܢ ܕܚܡܫܐ</quote>, <locus>fol. 147 a</locus>, <quote xml:lang="syr">ܒܡܥܗܕܢܘܬܐ ܕܐܘܢܓܠܝܘܢ
+                  ܕܡܬܝ</quote>, <locus>foll. 147 b, 148 b</locus>, <quote xml:lang="syr">ܒܟܬܒܐ ܕܬܪܝܢ ܕܣܝܡܬܐ</quote>, <locus>fol. 119 a</locus>, and <quote xml:lang="syr">ܒܡܥܗܕܢܘܬܐ ܕܡܙܡܘܪܐ
+                  ܗ̇ܘ ܕ܏ܟܐ</quote>, <locus>fol. 150 a</locus>.</note>
+              </msItem>
+              <msItem>
+                <locus to="" from="151a"/>
+                <author ref="">Josephus</author>
+                <title ref="" xml:lang="en">Extract from the Ecclesiastical History of
+                    <persName>Eusebius</persName>; the testimony of <persName>Josephus</persName>
+                  concerning <persName target="http://syriaca.org/person/2245">the Messiah</persName></title>
+                <rubric xml:lang="syr">ܡܢ ܐܩܠܣܝܣܛܝܩܐ ܕܐܘܣܒܝܘܣ̣ ܡܢ ܪܝܫܐ ܕ܏ܝܐ ܕ܏ܡܐܡ ܩܕܡܝܐ. ܣܗܕܘܬܐ
+                  ܕܝܘܣܝܦܘܣ̣ ܡܛܠ ܡܫܝܚܐ.</rubric>
+                <incipit xml:lang="syr"/>
+                <quote xml:lang="syr">
+                  <locus from="" to=""/>
+                </quote>
+                <explicit xml:lang="syr">
+                  <locus to="" from=""/>
+                </explicit>
+                <finalRubric xml:lang="syr">
+                  <locus to="" from=""/>
+                </finalRubric>
+                <note/>
+              </msItem>
+              <msItem defective="true">
+                <locus to="" from="151b"/>
+                <author ref=""/>
+                <title ref="" xml:lang="en">Extract from the Ecclesiastical History of <persName
+                    ref="http://syriaca.org/person/58">Zacharias Rhetor</persName>, concerning the
+                  end of <persName>Sergius the archiater</persName></title>
+                <rubric xml:lang="syr">ܡܢ ܐܩܠܣܝܣܛܝܩܐ ܕܙܟܪܝܐ̣. ܡܢ ܪܝܫܐ ܕ܏ܝܛ ܕܡܐܡܪܐ ܕ܏ܛ.܀ ܬܫܥܝܬܐ
+                  ܕܡܚܘܝܐ̣ ܕܐܝܢܐ ܫܘܠܡܐ ܗ̣ܘܐ ܠܣܪܓܝܣ ܐܪܟܝܛܪܘܣ.</rubric>
+                <incipit xml:lang="syr"/>
+                <quote xml:lang="syr">
+                  <locus from="" to=""/>
+                </quote>
+                <explicit xml:lang="syr">
+                  <locus to="" from=""/>
+                </explicit>
+                <finalRubric xml:lang="syr">
+                  <locus to="" from=""/>
+                </finalRubric>
+                <note>See <bibl>Land, Anecdota Syriaca, t. iii., p. 289</bibl>.</note>
+              </msItem>
+              <msItem defective="true">
+                <locus to="" from="152a"/>
+                <author ref="">Nestorius</author>
+                <title ref="" xml:lang="en">A letter of Nestorius</title>
+                <rubric xml:lang="syr"/>
+                <incipit xml:lang="syr"/>
+                <quote xml:lang="syr">
+                  <locus from="" to=""/>
+                </quote>
+                <explicit xml:lang="syr">ܐܢܬܘܢ ܕܝܢ ܠܗܠܝ̣ܢ ܠܐ ܬܩ̇ܒܠܘܢ. ܡܦܝ̈ܣܢܝܬܐ ܓܝܪ ܐܝܬܝܗܝܢ ܡ̈ܠܐ
+                  ܕܐܝܟ ܗܠܝ̣ܢ. ܘܠܐ ܗ̣̈ܘܝ ܫܪ̈ܝܪܬܐ. ܗܢܘ ܕܝ̣ܢ. ܕܐܪ̈ܣܝܣ ܕܘܠܢܝܛܝܢܘܣ ܘܕܐܦܘܠܝܢܐܪܝܘܣ: ܘܕܐܪܝܘܣ
+                  ܘܕܡܐܢܝ ܐܝܬܝܗܘܢ ܝܘ̈ܠܦܢܐ ܗܠܝܢ ܣܢ̈ܝ̣ܐ. ܘܡܚ̈ܒܠܢܐ ܕܢܦܫ̈ܬܐ̣ ܘܕܫ̇ܘܝܢ ܕܢܬܚܪܡܘܢ܀ ܐܠܐ ܗܝܡܢܘ̣
+                  ܐܝܟ ܒ̈ܢܝ ܬܫܡܫܬܢ ܩܕܝ̈ܫܐ ܦܐܠܘܝܐܢܘܣ ܘܠܐܘܢ. ܘܨ̇ܠܘ ܕܣܘܢܘܕܘܣ ܬܗܘܐ ܬܒܝܠܝܬܐ̣. ܥܠ ܕܒܗ̇
+                  ܝܘ̈ܠܦܢܐ ܕܝܠܝ̇. ܗ̇ܢܘܢ ܕܐܝܬܝܗܘܢ ܕܓܘܐ ܕܟܠܗܘܢ ܐܘܪ̈ܬܘܕܘܟܣܘ ܢܫܬܪܪܘܢ. ܡܣ̣ܒܪ ܐܢܐ ܓܝܪ ܟܕ
+                  ܗܕܐ ܬܗܘܐ̣. ܐܦ ܗܝ̇ ܗܘܝܐ ܒܡܥܕܪܢܘܬܐ ܕܐܠܗܐ. ܗܘ̣ܘ ܚܠܝܡܝܢ ܒܟܠܡܕܡ. ܝܬܝܪܐܝܬ ܒܗܝܡܢܘܬܐ̣
+                  ܪ̈ܚܡ̇ܝ ܠܡܫܝܚܐ.<locus to="" from=""/></explicit>
+                <finalRubric xml:lang="syr">
+                  <locus to="" from=""/>
+                </finalRubric>
+                <note>imperfect at the beginning</note>
+                <note>In it there are quota¬tions from Gregory Nazianzen, Julius, Basil, Athanasius,
+                  Celestinus of Rome, and Proclus of Constantinople</note>
+                <additions>
+                  <p></p>
+                  <list>
+                    <item>
+                      <locus from="153a" to=""/>
+                      <p>At the end, fol. 153 a, are appended the following remarks of the scribe or
+                        compiler, to prove the authenticity of this letter.</p>
+                      <p><quote xml:lang="syr">ܕܗ̣ܝ ܕܝܢ ܐܓܪܬܐ ܗܕܐ: ܕܢܣܛܘܪܝܘܣ ܐܝܬܝܗ̇ ܫܪܝܪܐܝܬ: ܘܠܘ ܓܒܘܠܝܐ ܐܝܬܝܗ̇ ܐܘ ܒ̣ܕܝܐ̣.
+                          ܣܗ̇ܕܝ̣ܢ ܟܠܗܘܢ ܒܢ̈ܝ ܣܝܥܬܗ ܕܢܣܛܘܪܝܘܣ. ܘܝܕܝܥܐܝܬ݂ ܫܡܥܘܢ ܗ̇ܘ ܕܡܬܩܪܐ ܒܪ ܛܒ̇ܚ̈ܐ̇.
+                          ܕܡܢܗ̇ ܟܕ ܡܢܗ̇ ܕܣܝܥܬܐ ܗܕܐ ܢܨ̇ܝܬ ܥܡ ܐܠܗܐ ܐܝܬܗܘܝ̇. ܗ̇ܘ ܕܐܦ ܛ̇ܢܢܐ ܗ̣ܘܐ ܚܠܦ
+                          ܢܣܛܘܪܝܘܣ. ܗܢܐ ܗܟܝܠ ܟܕ ܬܫܥܝܬܐ ܡܕܡ ܥܕܬܢܝܬܐ ܥ̇ܒܕ ܡܛܠ ܗ̇ܢܘܢ ܕܐܬ݀ܟܢܫܘ
+                          ܒܟܠܩܝܕܘܢܐ: ܘܣܢܐܓܪܘܬܐ ܟܐܡܬ ܥ̇ܒܕ ܚܠܦܝܗܘܢ ܟܡܐ ܕܡܫܟܚ: ܘܡ̇ܩܛܪܓ ܡ̇ܢ ܘܡܨ̇ܚܐ
+                          ܠܩܕܝܫܐ ܕܝܘܣܩܘܪܘܣ: ܡܫ̇ܒܚ ܕܝܢ ܘܡ̇ܩܠܣ ܠܢܣܛܘܪܝܘܣ̣. ܠܗ̇ ܠܐܓܪܬܐ ܗܕܐ̣. ܐܝܟ
+                          ܕܢܣܛܘܪܝܘܣ ܐܝܬܝܗ̇ ܡ̇ܝܬܐ ܠܗ̇ ܒܟܬܒܗ ܥܡ ܩܘܠܣܐ ܣܓܝܐܐ. <note>On <persName ref="http://syriaca.org/person/900">Simeon bar
+                            Tabbāhē</persName>, who flourished about the middle of the viiith cent.,
+                            see <bibl>Assemani, Bibl. Or., t. iii., pars i., p. 215</bibl>.</note></quote></p>
+                    </item>
+                  </list>
+                </additions>
+              </msItem>
+              <msItem>
+                <locus to="" from="153b"/>
+                <author ref=""/>
+                <title ref="" xml:lang="en">A short biography of <persName>Alexander the
+                    Great</persName></title>
+                <rubric xml:lang="syr">ܒܝܘܣ ܐܘ ܟܝܬ ܕܘܒܪܐ ܐܝܟ ܕܒܦܣ̈ܝܩܬܐ̣ ܕܐܠܟܣܢܕܪܘܣ ܡ̇ܠܟܐ
+                  ܕܡܩ̈ܕܘܢܝܐ.</rubric>
+                <incipit xml:lang="syr"/>
+                <quote xml:lang="syr">
+                  <locus from="" to=""/>
+                </quote>
+                <explicit xml:lang="syr">
+                  <locus to="" from=""/>
+                </explicit>
+                <finalRubric xml:lang="syr">
+                  <locus to="" from=""/>
+                </finalRubric>
+                <note>Edited by <bibl>de Lagarde in his Analecta Syriaca, pp. 205—208 (on p. 206,
+                    line 21, read ܣܓܝܐܐ ܟܢ̇ܫ)</bibl>.</note>
+              </msItem>
+              <msItem>
+                <locus to="" from="155a"/>
+                <author ref="http://syriaca.org/person/51">Severus of Antioch</author>
+                <title ref="" xml:lang="en">Extract from a letter of Severus of Antioch</title>
+                <rubric xml:lang="syr">ܕܩܕܝܫܐ ܣܐܘܪܐ ܦܛܪܝܪܟܐ̣. ܡ̇ܢܬܐ ܡܢ ܐܓܪܬܐ ܕܠܘܬ ܝܘܚܢܢ ܪܘܡܝܐ ܪܚ̇ܡ
+                  ܠܡܫܝܚܐ</rubric>
+                <incipit xml:lang="syr">ܡܛܠ ܕܝܢ ܫܘܐܠܐ ܗ̇ܘ ܕܒܗ ܫܐ̇ܠܬ: ܕܐܝܟܢܐ ܒܡܘܬܗ ܕܡܫܝܚܐ ܥܡ̇ܕܝܢܢ:
+                  ܘܒܬܠܝܬܝܘܬܐ ܩܕܝܫܬܐ ܬܘܒ ܡܫܬܡܠܐ ܗ̣ܘ ܥܡܕܐ̣. ܡܠܬܐ ܙܥܘܪܬܐ ܣ̇ܦܩܐ ܠܢ̇. ܏ܘܫ.</incipit>
+                <quote xml:lang="syr">
+                  <locus from="" to=""/>
+                </quote>
+                <explicit xml:lang="syr">
+                  <locus to="" from=""/>
+                </explicit>
+                <finalRubric xml:lang="syr">
+                  <locus to="" from=""/>
+                </finalRubric>
+                <note>He cites <persName target="http://syriaca.org/person/511">Gregory
+                    Nazianzen</persName>, <quote xml:lang="syr">ܒܡܐܡܪܐ ܗ̇ܘ ܕܡܛܠ ܦܨܚܐ</quote>, <locus>fol. 155
+                    b</locus>, and <persName>Proclus</persName>, <locus>fol. 156 a</locus>.</note>
+              </msItem>
+              <msItem>
+                <locus to="" from="157b"/>
+                <author ref="http://syriaca.org/person/51">Severus of Antioch</author>
+                <title ref="" xml:lang="en">Extract from another letter of Severus on the case of
+                  the <persName>priest Maximus</persName>, who had been convicted of
+                  adultery</title>
+                <rubric xml:lang="syr"> ܕܝܠܗ ܟܕ ܕܝܠܗ̣ ܐܓܪܬܐ ܕܠܘܬ ܣܘܠܘܢ ܐ܏ܦܝܣ ܕܣܠܘܩܝܐ</rubric>
+                <incipit xml:lang="syr"/>
+                <quote xml:lang="syr">
+                  <locus from="" to=""/>
+                </quote>
+                <explicit xml:lang="syr">
+                  <locus to="" from=""/>
+                </explicit>
+                <finalRubric xml:lang="syr">
+                  <locus to="" from=""/>
+                </finalRubric>
+                <note>He cites the Canons of the Councils of Neocaesarea, <locus>fol. 157 b</locus>,
+                  and Nicaea, <locus>fol. 158 a</locus>.</note>
+              </msItem>
+              <msItem>
+                <locus to="" from="158a"/>
+                <author ref=""/>
+                <title ref="" xml:lang="en">Extract from the Ecclesiastical History of <persName
+                    ref="http://syriaca.org/person/58">Zacharias Rhetor</persName>, on the public
+                  buildings, statues, and other decorations of the <placeName ref="http://syriaca.org/place/641">city of
+                    Rome</placeName></title>
+                <rubric xml:lang="syr">ܡܢ ܐܩܠܣܝܣܛܝܩܐ ܕܙܟܪܝܐ̣. ܡܢ ܪܝܫܐ ܕ܏ܝܘ ܕܡܐ܏ܡ ܏ܕܝ̣ ܡܛܠ ܨ̈ܒܘܬܐ
+                  ܘܬܘ̈ܩܢܐ ܕܒܪܘܡܐ ܡܕܝܢܬܐ.</rubric>
+                <incipit xml:lang="syr"/>
+                <quote xml:lang="syr">
+                  <locus from="" to=""/>
+                </quote>
+                <explicit xml:lang="syr">ܗܠܝܢ ܕܝܢ ܪܫ̣ܡ ܡܟܬܒܢܐ̣. ܟܕ ܡ̇ܒܟܐ ܠܗ̇ ܠܡܕܝܢܬܐ̇. ܡܛܠ ܕܥ̣ܠܘ ܠܗ̇
+                  ܒܪ̈ܒܪܝܐ ܒܙܒܢܗ ܘܚܪܒܘܗ̇.<locus to="" from=""/></explicit>
+                <finalRubric xml:lang="syr">
+                  <locus to="" from=""/>
+                </finalRubric>
+                <note>See <bibl>Mai, Scriptorum Vett. Nova Collectio, tom, x., pp. xii. and
+                    359</bibl>; <bibl>Land, Anecdota Syriaca, t. iii., p. 323</bibl>. </note>
+                <note>On <locus>fol. 158 b</locus> arc two metrical riddles,
+                  <quote xml:lang="syr">ܡܕܪ̈ܫܐ</quote>.</note>
+              </msItem>
+              <msItem>
+                <locus to="" from="158b"/>
+                <author ref=""/>
+                <title ref="" xml:lang="en">The Enchiridion of <persName>Jacob of Edessa</persName>,
+                  a philosophical tract, treating of the terms ܩܢܘܢܐ, ܐܘܣܝܐ ,ܟܝܢܐ , (φύσις) or ܦܘܣܝܣ
+                  ,ܝܬܐ, ܦܪܨܘܦܐ, and ܐܕܫܐ.</title>
+                <rubric xml:lang="syr">ܐܢܟܝܪܝܕܝܢ ܕܣܘ̈ܥܪܢܐ ܡܫ̈ܚܠܦܐ ܘܐ̈ܠܨܝܐ̣ ܡܛܠ ܦܘܣܝܣ ܐܘܟܝܬ ܟܝܢܐ.
+                  ܕܥܒܝܕ݂ ܠܚܣܝܐ ܝ݊ܥܩܘܒ ܐܦܝܣܩܘܦܐ ܕܐܘܪܗܝ<locus to="" from="158b"/></rubric>
+                <incipit xml:lang="syr"/>
+                <quote xml:lang="syr">
+                  <locus from="" to=""/>
+                </quote>
+                <explicit xml:lang="syr">ܫܠܡ ܟܪܛܝܣܐ ܕܡܬܩܪܐ ܐܢܟܝܪܝܕܝ̣ܢ ܐܘ ܟܝܬ ܕܒܐܝ̈ܕܝܐ<locus to=""
+                    from=""/></explicit>
+                <finalRubric xml:lang="syr">
+                  <locus to="" from=""/>
+                </finalRubric>
+                <note>On the word <quote xml:lang="syr">ܝܬܐ</quote> the author makes the following philological re¬mark,
+                    <locus>fol. 163 b</locus>: <quote xml:lang="syr">ܗܘܼ ܕܝܢ ܗܢܐ ܫܡܐ ܕܝܬܐ̣ ܠܠܫܢܐ ܡ̇ܢ ܗܢܐ ܣܘܪܝܝܐ ܐܘ ܟܝܬ
+                  ܢܗܪܝܐ̣. ܠܘ ܣ̇ܓܝ ܐܝܬܘܗܝ ܡܥܝܕܐ ܘܦܠܝܚܐ. ܠܗܘ ܕܝܢ ܣܘܪܝܝܐ ܘܦܠܝܣܛܝܢܝܐ̣. ܛܒ ܡܥܝܕܐ ܐܝܬܘܗܝ
+                  ܘܪܚܝܡܐ. ܡܠܘܢ ܕܝܢ ܠܠܫܢܐ ܗ̇ܘ ܥܒܪܝܐ ܘܩܕܡܝܐ. ܕܝܠܗ ܓܝܪ ܐܝܬܝܗ̇ ܚܫܚܬܗ ܕܗܢܐ ܫܡܐ ܝܬܝܪܐܝܬ.
+                  ܟܬܝܒ ܓܝܪ ܒܪܝܫܗ ܕܟܬܒܐ ܗ̇ܘ ܩܕܡܝܐ̣ ܕܠܘܬܗܘܢ: ܒܦܬܓܡܐ ܗ̇ܘ ܩܕܡܝܐ̣. ܒܪܝܫܝܬ ܒ̣ܪܐ ܐܠܗܐ. ܝܬ
+                  ܫܡܝܐ ܘܝܬ ܐܪܥܐ.</quote></note>
+                <note>Greek words are written on the margins of <locus>fol. 163 a and
+                  b</locus>.</note>
+              </msItem>
+              <msItem>
+                <locus to="" from="164b"/>
+                <author ref="">Jacob of Edessa</author>
+                <title ref="" xml:lang="en">Extracts from a discourse of Jacob of Edessa against
+                  certain persons, who transgressed the law of God and trampled under loot the
+                  canons of the Church, showing what Christianity is, and that it is the oldest of
+                  all religions</title>
+                <rubric xml:lang="syr">ܕܝܠܗ ܟܕ ܕܝܠܗ ܕܚܣܝܐ ܝܥܩܘܒ̣. ܡܢ ܡܐܡܪܐ ܕܡܟܣܢܘܬܐ ܕܠܘܩܒܠ ܐܢ̈ܫܝܢ
+                  ܡܪ̈ܚܐ ܘܥ̇ܒܪ̈ܝ ܥܠ ܢܡܘܣܐ ܕܐܠܗܐ ܘܕܝܫ̇ܝܢ ܠܩܢ̈ܘܢܐ ܥܕ̈ܬܢܝܐ̣. ܡܢ ܩܦܠܐܘܢ ܕܬܪܥܣܪ̈܀ ܥܠ ܗ̇ܝ
+                  ܕܡܢܐ ܗܝ ܟܪܝܣܗܝܢܘܬܐ̣. ܘܕܩ̇ܕܝܡܐ ܗܝ ܗܕܐ ܠܟܠܗܝܢ ܕܚ̈ܠܬܐ.</rubric>
+                <incipit xml:lang="syr"/>
+                <quote xml:lang="syr">
+                  <locus from="" to=""/>
+                </quote>
+                <explicit xml:lang="syr">
+                  <locus to="" from=""/>
+                </explicit>
+                <finalRubric xml:lang="syr">
+                  <locus to="" from=""/>
+                </finalRubric>
+                <note/>
+              </msItem>
+              <msItem>
+                <locus to="" from=""/>
+                <author ref=""/>
+                <title ref="" xml:lang="en">A collection of questions and answers on various
+                  subjects</title>
+                <rubric xml:lang="syr">ܫ̈ܘܐܠܐ ܕܡܫ̇ܐܠ ܐܢܫ ܠܚܒܪܗ̣ ܘܫܪܝܗܘܢ̇ ܡܛܠ ܣܘܥܪ̈ܢܐ ܣܓ̈ܝܐܐ
+                  ܘܡܫ̈ܚܠܦܐ</rubric>
+                <incipit xml:lang="syr"/>
+                <quote xml:lang="syr">
+                  <locus from="" to=""/>
+                </quote>
+                <explicit xml:lang="syr">
+                  <locus to="" from=""/>
+                </explicit>
+                <finalRubric xml:lang="syr">
+                  <locus to="" from=""/>
+                </finalRubric>
+                <note>Some of these are merely Scriptural riddles, of the kind of which Land has
+                  given specimens, from the following section, in his <bibl>Anecdd. Syr., torn, i.,
+                    p. 18, note 1</bibl>; others are Platonic definitions (see <bibl>Sachau, Ined.
+                    Syr., p. ܣܘ</bibl>).</note>
+                <msItem>
+                  <locus to="" from="168a"/>
+                  <author ref=""/>
+                  <title ref="" xml:lang="en">Section 1</title>
+                  <rubric xml:lang="syr">ܠܘܩܕܡ ܥܕܬ̈ܢܝܐ: ܡܢܐ ܐܝܬܝܗ̇ ܟܪܣܛܝܢܘܬܐ܀ ܫܪܪܐ ܕܝܘܿܠܦܢܐ̣
+                    ܘܡܛܝܒܘܬܐ ܕܕܘܒܪ̈ܐ ܢܨ̈ܝܚܐ. ܘ܏ܫ.</rubric>
+                  <incipit xml:lang="syr"/>
+                  <quote xml:lang="syr">
+                    <locus from="" to=""/>
+                  </quote>
+                  <explicit xml:lang="syr">
+                    <locus to="" from=""/>
+                  </explicit>
+                  <finalRubric xml:lang="syr">
+                    <locus to="" from=""/>
+                  </finalRubric>
+                  <note/>
+                </msItem>
+                <msItem>
+                  <locus to="" from="168b"/>
+                  <author ref=""/>
+                  <title ref="" xml:lang="en">Section 2</title>
+                  <rubric xml:lang="syr">ܐܚܪ̈ܢܐ ܦܝܠܘܣ̈ܦܝܐ̣ ܘܫܪܝܗܘܢ. ܡܢܐ ܐܝܬܘܗܝ ܐܠܗܐ܀ ܟܝܢܐ ܚܝܐ ܘܠܐ
+                    ܡܝܘܬܐ: ܕܣ̇ܦܩ ܠܟܠ ܛܒ̈ܢ: ܘܐܝܬܘܗܝ ܡܢ ܥܠܡ ܘܕܠܐ ܫܘܠܡ̣. ܘܥܠܬ݂ܐ ܘܒܪܘܿܝܐ ܕܟܠ ܛܒ̈ܢ.
+                    ܏ܘܫ.</rubric>
+                  <incipit xml:lang="syr"/>
+                  <quote xml:lang="syr">
+                    <locus from="" to=""/>
+                  </quote>
+                  <explicit xml:lang="syr">
+                    <locus to="" from=""/>
+                  </explicit>
+                  <finalRubric xml:lang="syr">
+                    <locus to="" from=""/>
+                  </finalRubric>
+                  <note/>
+                </msItem>
+              </msItem>
+              <msItem>
+                <locus to="" from="175b"/>
+                <author ref=""/>
+                <title ref="" xml:lang="en">A similar collection of questions and answers</title>
+                <rubric xml:lang="syr">ܬܘܒ ܦܠܐ̈ܬܐ ܐܚܪ̈ܢܝܬܐ̣. ܕܡܛܠ ܡܕܡ ܡܕܡ ܡܢ ܡ̈ܠܐ ܕܟܬ̈ܒܐ ܩܕܝܫ̈ܐ̣.
+                  ܕܥܒ̈ܝܕܢ ܐܝܟ ܕܠܕܘܪܫܐ ܕܝܠܘ̈ܦܐ̣. ܘܡܛܠ ܦܘܪܓܝܐ.</rubric>
+                <incipit xml:lang="syr"/>
+                <quote xml:lang="syr">
+                  <locus from="" to=""/>
+                </quote>
+                <explicit xml:lang="syr">
+                  <locus to="" from=""/>
+                </explicit>
+                <finalRubric xml:lang="syr">
+                  <locus to="" from=""/>
+                </finalRubric>
+                <note/>
+              </msItem>
+              <msItem>
+                <locus to="" from="178a"/>
+                <author ref=""/>
+                <title ref="" xml:lang="en">Explanation of some passages in Scripture</title>
+                <rubric xml:lang="syr">ܦܘܫܩܐ ܕܡ̈ܠܐ ܡܕܡ ܡܕܡ ܡܢ ܟܬܒ̈ܐ</rubric>
+                <incipit xml:lang="syr"/>
+                <quote xml:lang="syr">
+                  <locus from="" to=""/>
+                </quote>
+                <explicit xml:lang="syr">
+                  <locus to="" from=""/>
+                </explicit>
+                <finalRubric xml:lang="syr">
+                  <locus to="" from=""/>
+                </finalRubric>
+                <note>At the end there is a ܦܠܐܬܐ or riddle</note>
+              </msItem>
+              <msItem>
+                <locus to="" from="180a"/>
+                <author ref=""/>
+                <title ref="" xml:lang="en">The names of the wives of the patriarchs, according to
+                  the hook of the "<ref>Jubihaea</ref>" or “<ref>Parva Genesis</ref>." </title>
+                <rubric xml:lang="syr">ܫ̈ܡܗܐ ܕܢܫ̈ܐ ܕܪ̈ܝܫܝ ܐܒܗ̈ܬܐ ܩܕܡ̈ܝܐ̣. ܐܝܟ ܟܬܒܐ ܕܠܘܬ ܥܒܪ̈ܝܐ ܗ̇ܘ
+                  ܕܡܬܩܪܐ ܝܘܒܝܠܝܐ</rubric>
+                <incipit xml:lang="syr"/>
+                <quote xml:lang="syr">
+                  <locus from="" to=""/>
+                </quote>
+                <explicit xml:lang="syr">
+                  <locus to="" from=""/>
+                </explicit>
+                <finalRubric xml:lang="syr">
+                  <locus to="" from=""/>
+                </finalRubric>
+                <note>This section has been edited by <bibl>Ceriani in the "Monumenta Sacra et
+                    Profana etc.," tom, ii., fasc. i., p. ix. (on page x., in the first line of the
+                    second column, read ܕܢܝܫܝܗܘܢ for ܕܢܝܫܝܢ)</bibl>.</note>
+              </msItem>
+              <msItem>
+                <locus to="" from="180b"/>
+                <author ref=""/>
+                <title ref="" xml:lang="en">Explanation of the Hebrew names occurring in
+                  Scripture</title>
+                <rubric xml:lang="syr">ܦܘܫܩܐ̣ ܕܫ̈ܡܗܐ ܥܒܪ̈ܝܐ ܕܐܝܬ ܒܟ̈ܬܒܐ ܩܕܝܫ̈ܐ</rubric>
+                <incipit xml:lang="syr"/>
+                <quote xml:lang="syr">ܐܕܡ̣ ܡܢ ܐܕܡܬܐ܀ ܐܕܡܬܐ̣ ܣܡܩܬܐ܀ ܚܘܐ̣ ܚ̈ܝܐ܀ ܩܐܝ̣ܢ ܩ̇ܢܝܬ܀ ܫܝܬ݂
+                  ܫܬܝܬܝܘܬܐ܀ ܏ܘܫ.<locus from="" to=""/></quote>
+                <explicit xml:lang="syr">
+                  <locus to="" from=""/>
+                </explicit>
+                <finalRubric xml:lang="syr">
+                  <locus to="" from=""/>
+                </finalRubric>
+                <note/>
+              </msItem>
+              <msItem>
+                <locus to="" from="184a"/>
+                <author ref=""/>
+                <title ref="" xml:lang="en">Statement of the number of verses in each of the books
+                  of Scripture</title>
+                <rubric xml:lang="syr">ܪܘܫܡܐ̣ ܡܛܠ ܦܬܓ̈ܡܐ ܕܐܝܬ ܒܟ̈ܬܒܐ</rubric>
+                <incipit xml:lang="syr"/>
+                <quote xml:lang="syr">
+                  <locus from="" to=""/>
+                </quote>
+                <explicit xml:lang="syr">
+                  <locus to="" from=""/>
+                </explicit>
+                <finalRubric xml:lang="syr">
+                  <locus to="" from=""/>
+                </finalRubric>
+                <note/>
+              </msItem>
+              <msItem>
+                <locus to="" from="184a"/>
+                <author ref="http://syriaca.org/person/122">George, bishop of the Arabs</author>
+                <title ref="" xml:lang="en">A short Commentary on the Sacraments of the Church, by a
+                  bishop named George (probably George, bishop of the Arabs), treating of Baptism
+                  (ܡܥܡܘܕܝܬܐ), the holy Eucharist (ܩܘܿܪܒܐ), and the Consecration of the Chrism (ܩܘܕܫ
+                  ܡܘܪܘܢ)</title>
+                <rubric xml:lang="syr">ܬܘܒ ܦܘܫܩܐ ܕܪ̈ܐܙܐ ܕܥܕܬܐ̣. ܕܥܒܝܕ݂ ܠܐܢܫ ܐܦܝܣܩܘܦܐ ܕܫܡܗ
+                  ܓܐܘܪܓܝ</rubric>
+                <incipit xml:lang="syr">ܡܛܠ ܗܟܝܠ ܕܥ̣ܒܕܘ ܦܘܫܩܐ ܕܪ̈ܐܙܐ̇ ܡ̈ܠܦܢܐ ܕܥܕܬܐ: ܦܬܝܐܝܬ ܘܩܛܝܢܐܝܬ
+                  ܘܡܥܠܝܐܝܬ: ܝܬܝܪܐܝܬ ܕܝܢ ܩܕܝܫܐ ܕܝܘܢܘܣܝܘܣ ܬܠܡܝܕܗ ܕܦܘܠܘܣ ܫܠܝܚܐ: ܚܕ ܡܢ ܕ̈ܝ̇ܢܐ ܕܐܪܝܘܣ
+                  ܦܘܓܘܣ: ܗ̇ܘ ܕܗ̣ܘܐ ܐܦܝܣܩܘܦܐ ܕܐܬܐܢܣ ܡܕܝܢܬܐ̣. ܥ̇ܒܕܬ ܐܦ ܐܢܐ ܐܝܟ ܕܒܦܣ̈ܝܩܬܐ̣. ܠܕܘܪܫܐ
+                  ܕܪ̈ܚ̇ܡܝ ܝܘܠܦܢܐ. ܝܬܝܪܐܝܬ݂ ܕܗ̇ܢܘܢ ܕܐܝܬܝܗܘܢ ܡ̈ܚܝܠܐ ܕܐܟܘܬܢ̇. ܘܠܝܬ ܠܗܘܢ ܕܐܡܝܢܐܝܬ
+                  ܒܦܢܩ̈ܝܬܐ ܕܐ̈ܒܗܬܐ ܩܕܝ̈ܫܐ ܢܩ̣ܪܘܢ̇. ܐܘ ܡܛܠ ܕܠܐ ܫܟܝܚܝܢ ܠܗܘܢ̇. ܐܘ ܬܘܒ ܡܛܠ ܗ̇ܝ ܕܠܘ ܟܠܢܫ
+                  ܡܫܟܚ ܕܢܕܪܟ ܣܘܟܠܐ ܡܥܠܝܐ ܕܐܒܗ̈ܬܐ. ܡܛܠܗܕܐ ܥ̇ܒܕܬ ܐܢܐ ܒܟܪ̈ܝܬܐ: ܗ̇ܘ ܡܕܡ ܕܠܗܘܢ ܠܡ̈ܠܦܢܐ
+                  ܩܕܝ̈ܫܐ ܥܒܝܕ: ܘܠܗ ܠܕܝܘܢܘܣܝܘܣ ܘܠܐܚܪ̈ܢܐ ܐܡܝܪ ܩܛܝܢܐܝܬ݂. ܒܡܡܠܠܐ ܦܫܝܩܐ ܘܦܫܝܛܐ̣. ܠܦܘܬ
+                  ܡܫܡܥܬܐ ܕܟܠܢܫ ܕܣܢܝܩ ܠܡܕܥ ܚܝܠܗܘܢ ܕܪ̈ܐܙܐ ܩܕܝ̈ܫܐ܀</incipit>
+                <quote xml:lang="syr">
+                  <locus from="" to=""/>
+                </quote>
+                <explicit xml:lang="syr">
+                  <locus to="" from=""/>
+                </explicit>
+                <finalRubric xml:lang="syr">
+                  <locus to="" from=""/>
+                </finalRubric>
+                <note/>
+              </msItem>
+              <msItem>
+                <locus to="" from="191a"/>
+                <author ref=""/>
+                <title ref="" xml:lang="en">Philosophical definitions and discussions</title>
+                <rubric xml:lang="syr">ܫܪܒܐ ܕܦܝܠܘ̈ܣܘܦܐ</rubric>
+                <incipit xml:lang="syr"/>
+                <quote xml:lang="syr">
+                  <locus from="" to=""/>
+                </quote>
+                <explicit xml:lang="syr">
+                  <locus to="" from=""/>
+                </explicit>
+                <finalRubric xml:lang="syr">
+                  <locus to="" from=""/>
+                </finalRubric>
+                <note>It consists of a number of short sections, of which the following are the
+                  titles.<quote xml:lang="syr">ܡܛܠ ܦܘܠܓܐ ܕܐܘܣܝܐ: ܐܘܣܝܐ ܕܓܘܐ̇ ܗ̇ܝ ܐܚܘܕܬܐ ܕܟܠ̣. ܡܬܦܠܓܐ ܠܓܘܫ̈ܡܐ̣ ܘܠܠܐ
+                  ܓܫ̈ܝܡܐ. ܏ܘܫ܀ ܥܠ ܢܝܫ̣ܐ ܕܡܠܬܐ ܕܡܪܟܒܐ̣. ܘܥܠ ܢܝܫ̣ܐ ܫ̣ܪܘܝܐ ܕܡܪܟܒܐ܀ ܬܘܒ̣ ܦܘܠܓܐ ܐܚܪܢܐ
+                  ܕܐܘܣܝܐ. ܐܘܣܝܐ ܐܝܬܝܗ̣̇ ܓܢܣ ܓܢܣ̈ܝܢ. ܘܣܓ̈ܝܐܬܐ ܚܒ̇ܫܐ ܠܓܘ ܡܢܗ̇. ܏ܘܫ܀ ܬܘܒ̣ ܡܛܠ ܐܘܣܝܐ
+                  ܓܢܣܢܝܬܐ ܘܐܕܫܐ܀ ܬܘܒ̣ ܡܛܠ ܐܘܣܝܐ ܘܓܢܣܐ ܘܐܕܫܐ. ܘܫܘܚܠܦܐ ܘܕܝܠܝܬܐ ܘܓܕܫܐ܀ ܕܐܝܠܝܢ ܐܝܬܝܗܝܢ
+                  ܕܝܠܝ̈ܬܗ̇ ܕܐܘܣܝܐ ܘܐܦ ܬܚܘ̈ܡܝܗ̇܀ ܬܘܒ ܡܛܠ ܬܚܘܡܐ܀ ܥܠ ܦܘܪܫܢܐ ܕܒܪ̈ܝ̣ܬܐ܀ ܡܛܠ ܦܘܠܓܐ
+                  ܕܦܝܠܘܣܘܦܘܬܐ̣. ܘܥܠ ܗ̇ܝ ܕܒܟܡܐ ܙܢ̈ܝܐ ܡܬܐܡܪ ܡܕܡ ܡܕܡ܀ ܥܠ ܟܡܝܘܬܐ ܘܡ̈ܢܘܬܗ̇܀ ܡܛܠ ܗܘܠܐ
+                  (ὔλη) ܘܡ̈ܢܘܬܗ̇܀ ܡܛܠ ܩܛܐܓܘܪ̈ܝܣ ܘܟܡܝܘܬܗܝܢ܀ ܡܛܠ ܡ̈ܘܙܓܘܗܝ ܘܛܘܟ̈ܣܘܗܝ ܘܐܣܟ̈ܡܘܗܝ ܘܙܘ̈ܥܘܗܝ
+                  ܘܪ̈ܓܫܘܗܝ ܕܦܓܪܐ̇. ܘܕܠܩܘܒܠܐ ܕܙܘܥ̈ܘܗܝ܀ ܡܛܠ ܫܘܬܦܘܬܐ ܕܫܘܝܘܬ ܫܡܐ ܘܬܚܘܡܐ܀ ܕܡܢܐ ܡܫܚܠܦܐ
+                  ܫܘܝ̣ܘܬ ܫܡܐ ܡܢ ܕܡܝ̣ܘܬ ܫܡܐ܀ ܕܒܟܡܐ ܙܢ̈ܝܐ ܡܬ݀ܦܠܓ ܟܠܡܕܡ ܕܡܬ݀ܦܠܓ܀ ܕܒܟܡܐ ܙܢ̈ܝܐ ܗ̇ܘܝܐ ܠܐ
+                  ܫܠ̣ܡܘܬܐ܀ ܕܒܟܡܐ ܙܢ̈ܝܐ ܡܬܥܩܒܐ ܟܠ ܨܒܘܬܐ܀ ܕܒܟܡܐ ܙܢ̈ܝܐ ܡܬܐܡܪ ܪܘܟܒܐ܀ ܕܒܟܡܐ ܙܢܝ̈ܐ ܡܬܐܡܪܐ
+                  ܚܕܝܘܬܐ܀ ܬܘܒ ܡܛܠ ܚܕܝܘܬܐ ܟܝܢܝܬܐ̣. ܕܒܟܡܐ ܙܢ̈ܝܐ ܡܬܐܡܪܐ܀ ܕܟܡܐ ܐܝܬܝܗܘܢ ܐܕܫ̈ܝܗ̇ ܕܡܠܬܐ܀</quote>
+                </note>
+              </msItem>
+              <msItem>
+                <locus to="" from=""/>
+                <author ref="http://syriaca.org/person/744">Simeon Stylites</author>
+                <title ref="" xml:lang="en">Letters of Simeon Stylites</title>
+                <rubric xml:lang="syr">ܐ̈ܓܪܐ ܕܩܕܝܫܐ ܡܪܝ ܫܡܥܘܢ ܕܐܣܛܘܢܐ. ܕܣܗ̈ܕܢ ܥܠܘܗܝ̣ ܕܠܐ ܩܒܠܗ̇
+                  ܠܣܘܢܘܕܘܣ ܕܟܠܩܝܕܘܢܐ.</rubric>
+                <incipit xml:lang="syr"/>
+                <quote xml:lang="syr">
+                  <locus from="" to=""/>
+                </quote>
+                <explicit xml:lang="syr">
+                  <locus to="" from=""/>
+                </explicit>
+                <finalRubric xml:lang="syr">
+                  <locus to="" from=""/>
+                </finalRubric>
+                <note/>
+                <msItem>
+                  <locus to="" from="199b"/>
+                  <author ref="">Emperor Leo</author>
+                  <author ref="http://syriaca.org/person/744">Simeon Stylites</author>
+                  <title ref="" xml:lang="en">To the emperor Leo, <note>See <bibl>Assemani, Bibl. Or., t. i., p. 254</bibl>.</note></title>
+                  <rubric xml:lang="syr">ܩܕܡܝܬܐ̣ ܠܘܬ ܠܐܘܢ ܡ̇ܠܟܐ ܕܐܡܠܟ ܒܬܪ ܡܪܩܝܢܘܣ.</rubric>
+                  <incipit xml:lang="syr"/>
+                  <quote xml:lang="syr">
+                    <locus from="" to=""/>
+                  </quote>
+                  <explicit xml:lang="syr">
+                    <locus to="" from=""/>
+                  </explicit>
+                  <finalRubric xml:lang="syr">
+                    <locus to="" from=""/>
+                  </finalRubric>
+                  <note></note>
+                </msItem>
+                <msItem>
+                  <locus to="" from="200a"/>
+                  <author ref="">Abbat Jacob of Kaphrā Rěhīmā</author>
+                  <author ref="http://syriaca.org/person/744">Simeon Stylites</author>
+                  <title ref="" xml:lang="en">To the abbat Jacob of Kaphrā Rěhīmā</title>
+                  <rubric xml:lang="syr">ܐܚܪܬܐ̣ ܠܘܬ ܡܪܝ ܝܥܩܘܒ ܕܟܦܪܐ ܪܚܝܡܐ.</rubric>
+                  <incipit xml:lang="syr"/>
+                  <quote xml:lang="syr">
+                    <locus from="" to=""/>
+                  </quote>
+                  <explicit xml:lang="syr">
+                    <locus to="" from=""/>
+                  </explicit>
+                  <finalRubric xml:lang="syr">
+                    <locus to="" from=""/>
+                  </finalRubric>
+                  <note/>
+                </msItem>
+                <msItem>
+                  <locus to="" from="201a"/>
+                  <author ref="http://syriaca.org/person/2449">John I, patriarch of Antioch</author>
+                  <author ref="http://syriaca.org/person/744">Simeon Stylites</author>
+                  <title ref="" xml:lang="en">To John, patriarch of Antioch, <note>John I., A.D. 428-441. See <bibl>Le Quien, Or. Christ., t. ii., eol.
+                    721</bibl>.</note> concerning
+                    <persName ref="http://syriaca.org/person/655">Nestorius</persName></title>
+                  <rubric xml:lang="syr">ܠܘܬ ܝܘܚܢܢ ܕܐܢܛܝܘܟܝܐ̣. ܡܛܠ ܢܣܛܘܪܝܘܣ</rubric>
+                  <incipit xml:lang="syr"/>
+                  <quote xml:lang="syr">
+                    <locus from="" to=""/>
+                  </quote>
+                  <explicit xml:lang="syr">
+                    <locus to="" from=""/>
+                  </explicit>
+                  <finalRubric xml:lang="syr">
+                    <locus to="" from=""/>
+                  </finalRubric>
+                  <note></note>
+                  <additions>
+                    <p>To these are appended</p>
+                    <list>
+                      <item>
+                        <locus from="201a" to=""/>
+                        <p>A letter written by <persName>Alexander of Mabūg</persName> and
+                          <persName>Andrew of Samosata</persName> to <persName ref="http://syriaca.org/person/2449">John of
+                            Antioch</persName> and <persName ref="http://syriaca.org/person/781">Theodoret of Cyrus</persName>,
+                          concerning <persName ref="http://syriaca.org/person/744">Simeon Stylites</persName> and <persName>Jacob of
+                            Kaphrā Rěhīmā</persName></p>
+                        <p><quote xml:lang="syr">ܬܘܒ ܐܓܪܬܐ ܕܟܬ̣ܒܘ ܐܠܟܣܢܪܘܣ ܕܡܒܘܓ ܘܐܢܕܪܝܐ ܕܫܡܝܫܛ: ܠܘܬ ܝܘܚܢܢ ܕܐܢܛܝܘܟܝܐ ܘܬܐܘܕܘܪܝܛܐ
+                            ܕܩܘܪܘܣ̣. ܡܛܠܬܗ ܕܩܕܝܫܐ ܡܪܝ ܫܡܥܘܢ̣. ܘܡܛܠ ܡܪܝ ܝܥܩܘܒ ܕܟܦܪܐ ܪܚܝܡܐ.</quote></p>
+                      </item>
+                      <item>
+                        <locus from="201b" to=""/>
+                        <p>An extract from the Ecclesiastical History of <persName ref="http://syriaca.org/person/74">John of
+                            Asia</persName>, concerning <persName>Theodoret</persName></p>
+                        <p>
+                          <quote xml:lang="syr">ܡܢ ܐܩܠܣܝܣܛܝܩܐ ܕܝܘܚܢܢ ܕܐܣܝܐ̣ ܡܛܠ ܬܐܘܕܘܪܝܛܐ</quote>
+                          <quote xml:lang="en">See <bibl>Land, Anecd. Syr., t. ii., p.
+                              363</bibl>.<locus from="" to=""/></quote>
+                        </p>
+                      </item>
+                    </list>
+                  </additions>
+                </msItem>
+              </msItem>
+              <msItem>
+                <locus to="" from="201b"/>
+                <author ref=""/>
+                <title ref="" xml:lang="en">Demonstrations from the Old Testament against the Jews
+                  and other unbelievers, in 8 sections</title>
+                <rubric xml:lang="syr">ܟܘܢܫܐ ܕܬܚ̈ܘܝܬܐ ܡܢ ܟܬ̈ܒܐ ܩܕ̈ܝܫܐ ܕܥܬܝܩܬܐ̣. ܠܘܩܒܠ ܝ̈ܗܘܕܝܐ ܘܫܪܟܐ
+                  ܕܠܐ ܡܗܝ̈ܡܢܐ</rubric>
+                <incipit xml:lang="syr"/>
+                <quote xml:lang="syr">
+                  <locus from="" to=""/>
+                </quote>
+                <explicit xml:lang="syr">
+                  <locus to="" from=""/>
+                </explicit>
+                <finalRubric xml:lang="syr">
+                  <locus to="" from=""/>
+                </finalRubric>
+                <note/>
+              </msItem>
+            </msItem>
+          </msContents>
+          <physDesc>
+            <objectDesc form="codex">
+              <supportDesc material="perg">
+                <extent>
+                  <measure unit="content_pending" quantity="-1"/>
+                </extent>
+                <foliation/>
+                <collation/>
+                <condition>
+                  <list>
+                    <item>
+                      <p>Vellum, about 9 7/8 in. by 6 5/8, consisting of 294 leaves, some of which
+                        are much stained and the last is mutilated. The quires, 30 in number, are
+                        signed with letters. There are from 27 to 41 lines in each page. Leaves are
+                        wanting after foll. 8 and 151. This manuscript seems to have been written by
+                        three hands, foll. 1—16 and foll. 28—79 b being in a good, though rather
+                        coarse, Estrangělā; foll. 79 b —294 in a finer Estrangělā; and foll. 17— 27
+                        in a more current hand. It belongs to the end of the viiith or beginning of
+                        the ixth cent. The contents are of a very miscellaneous character.</p>
+                    </item>
+                  </list>
+                </condition>
+              </supportDesc>
+              <layoutDesc>
+                <p>Content pending</p>
+              </layoutDesc>
+            </objectDesc>
+            <handDesc>
+              <handNote scope="" script=""
+                medium="">
+                <desc></desc>
+              </handNote>
+            </handDesc>
+            <additions>
+              <p></p>
+              <list>
+                <item>
+                  <locus from="" to=""/>
+                  <p></p>
+                  <p><quote xml:lang="syr"></quote></p>
+                </item>
+              </list>
+            </additions>
+            <bindingDesc>
+              <p>Content pending</p>
+            </bindingDesc>
+            <sealDesc>
+              <p>Content pending</p>
+            </sealDesc>
+            <accMat/>
+          </physDesc>
+          <history>
+            <origin>
+              <origDate notBefore="0775" notAfter="0825" from="" to="" when="">the end of the viiith
+                or beginning of the ixth cent.</origDate>
+              <origPlace ref="" xml:lang=""></origPlace>
+            </origin>
+            <provenance/>
+            <acquisition/>
+          </history>
+          <additional/>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>Content pending</p>
+    </encodingDesc>
+    <profileDesc/>
+    <revisionDesc status="draft">
+      <change when="" who="http://syriaca.org/documentation/editors.xml#cchen">Initial TEI encoding.</change>
+      <change type="planned" subtype="question">Question in Word Doc to be Addressed: The additional
+        item found in the MS item has a footnote, see p 983 Wright II</change>
+    </revisionDesc>
+  </teiHeader>
+  <facsimile>
+    <formula>Content pending</formula>
+  </facsimile>
+  <text>
+    <body>
+      <bibl>Content pending</bibl>
+    </body>
+  </text>
+</TEI>

--- a/data/3_drafts/ClaireChen/29D.xml
+++ b/data/3_drafts/ClaireChen/29D.xml
@@ -1,0 +1,488 @@
+<?xml version="1.0" encoding="utf-8"?>
+<?oxygen RNGSchema="https://raw.githubusercontent.com/wlpotter/syriaca-wright-catalog/master/schemas/enrich-syriaca.rnc" type="compact"?>
+<?xml-stylesheet type="text/css" href="https://raw.githubusercontent.com/srophe/wright-catalogue/master/parameters/wright-mss.css"?>
+<TEI xml:lang="en" xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader xmlns="http://www.tei-c.org/ns/1.0">
+    <fileDesc>
+      <titleStmt>
+        <title>Content pending</title>
+      </titleStmt>
+      <editionStmt>
+        <p>Content pending</p>
+      </editionStmt>
+      <publicationStmt>
+        <p>Content pending</p>
+      </publicationStmt>
+      <sourceDesc>
+        <msDesc>
+          <msIdentifier>
+            <idno type="URI">29</idno>
+            <altIdentifier>
+              <idno type="BL-Shelfmark">Add. 12,154</idno>
+            </altIdentifier>
+          </msIdentifier>
+          <msContents>
+            <summary/>
+            <textLang mainLang="syr"/>
+            <msItem>
+              <locus to="" from=""/>
+              <author ref=""/>
+              <title ref="" xml:lang="en"><note>A tract in defence of Monophysite doctrines</note>
+                Demonstrations, or Evidences, concerning the Dispensation of the Messiah <note>divided
+                  into fifteen chapters</note></title>
+              <rubric xml:lang="syr">$$$SEE 29A$$$</rubric>
+              <incipit xml:lang="syr"/>
+              <quote xml:lang="syr">$$$SEE 29A$$$<locus from="" to=""/></quote>
+              <explicit xml:lang="syr">
+                <locus to="" from=""/>
+              </explicit>
+              <finalRubric xml:lang="syr">
+                <locus to="" from=""/>
+              </finalRubric>
+              <note>$$$SEE 29A$$$</note>
+              <msItem>
+                <locus to="" from=""/>
+                <author ref="http://syriaca.org/person/122">George, bishop of the Arabs</author>
+                <title ref="" xml:lang="en">A collection of letters of George, bishop of the
+                  Arabs</title>
+                <rubric xml:lang="syr"/>
+                <incipit xml:lang="syr"/>
+                <quote xml:lang="syr">
+                  <locus from="" to=""/>
+                </quote>
+                <explicit xml:lang="syr">
+                  <locus to="" from=""/>
+                </explicit>
+                <finalRubric xml:lang="syr">
+                  <locus to="" from=""/>
+                </finalRubric>
+                <note/>
+                <msItem>
+                  <locus to="" from="222a"/>
+                  <author ref="http://syriaca.org/person/122">George, bishop of the Arabs</author>
+                  <author ref="">Mārī, ܡܪܝ ܡܐܪܝ, abbat of the <placeName>monastery of Tell-'Adā,
+                      ܬܠܥܕܐ</placeName></author>
+                  <title ref="" xml:lang="en">Part A</title>
+                  <rubric xml:lang="syr">ܕܚܣܝܐ ܓܐ݊ܘܪܓܝ ܐܦܝܣܩܘܦܐ ܕܐܬܢ̈ܘܟܝܐ ܘܕ̈ܛܘܥܝܐ ܘܕܥ̈ܩܘܠܝܐ̣. ܦܘܢܝ
+                    ܦܬܓܡܐ ܒܦܣ̈ܝܩܬܐ̣. ܠܘܬ ܫ̈ܘܐܠܐ ܏ܟܒ ܗܪ̈ܛܝܩܐ ܗܠܝܢ ܕܡܢ ܠܬܚܬ ܟܬܝܒܝܢ <note>I.e., bishop of the tribe of Tanūkh, %, of the ܛ̈ܘܥܝܐ (?), and of the people
+                      of ‘Akūlā, %, or al-Kūfah. See <bibl>Assemani, Bibl. Or., t. ii., Dissert. De
+                        Monophys., art. Ix.</bibl>; and <bibl>G. Hoffmaun, De Hermeneuticis apud Syros
+                          Aristoteleis, p. 148</bibl>. </note></rubric>
+                  <incipit xml:lang="syr"/>
+                  <quote xml:lang="syr">ܐܬ̇ܬܨܚ ܘܐܬ݂ܟܬܒ ܗܠܝ̣ܢ. ܒܝܪܚ ܐܝܪ ܕܫܢܬ ܐ܏ܟܚ ܒܕܝ̈ܘܢܝܐ.<locus
+                      from="" to=""/></quote>
+                  <explicit xml:lang="syr">
+                    <locus to="" from=""/>
+                  </explicit>
+                  <finalRubric xml:lang="syr">
+                    <locus to="" from=""/>
+                  </finalRubric>
+                  <note>This letter is addressed to <persName>Mārī, ܡܪܝ ܡܐܪܝ, abbat of the monastery
+                      of Tell-'Adā, ܬܠܥܕܐ</persName>, and directed chiefly against the Nestorians. </note>
+                  <note>It is dated <date>A. Gr. 1028</date>, <date>A.D. 717</date></note>
+                  <additions>
+                    <p>To it are appended</p>
+                    <list>
+                      <item>
+                        <locus from="233b" to=""/>
+                        <p>Replies to questions of the Nestorians</p>
+                        <p><quote xml:lang="syr">ܫ̈ܘܐܠܐ ܥܣ̈ܩܐ ܢܣܛܘܪ̈ܝܢܐ̣ ܘܫ̈ܘܐܠܐ ܕܠܘܩܒܠܗܘܢ.</quote></p>
+                      </item>
+                      <item>
+                        <locus from="236a" to=""/>
+                        <p>Replies to the questions raised in the second letter of
+                          <persName>Succensus</persName> to <persName ref="http://syriaca.org/person/430">Cyril of
+                            Alexandria</persName></p>
+                        <p>
+                          <quote xml:lang="syr">ܬܘܒ ܫ̈ܘܐܠܐ ܗܪ̈ܛܝܩܝܐ ܗ̇ܢܘܢ ܕܣܝ̣ܡܝܢ ܒܐܓܪܬܐ ܕܬܪ̈ܬܝܢ
+                            ܕܣܘܩܢܣܘܣ ܕܠܘܬ ܩܕܝܫܐ ܩܘܪܝܠܘܣ̣. ܘܫ̈ܘܐܠܐ ܕܠܘܩܒܠܗܘܢ</quote>
+                        </p>
+                      </item>
+                      <item>
+                        <locus from="237a" to=""/>
+                        <p>Reply to a question addressed by <persName>the heretic Probus</persName>
+                          to the monks of <placeName ref="http://syriaca.org/place/10">Antioch</placeName></p>
+                        <p>
+                          <quote xml:lang="syr">ܫܘܐܠܐ̣ ܕܪܫܝܥܐ ܦܪܘܒܐ̇. ܗ̇ܘ ܕܫ̇ܐܠ ܠܢܟ̈ܦܐ ܕܝܪ̈ܝܐ
+                            ܒܐܢܛܝܘܟܝܐ ܡܕܝܢܬܐ</quote>
+                        </p>
+                      </item>
+                    </list>
+                  </additions>
+                </msItem>
+                <msItem>
+                  <locus to="" from="237b"/>
+                  <author ref="">Deacon Bar-had-bě-shabbā of the <placeName>convent of Beth-Mělūtā
+                      or Tělīthā</placeName></author>
+                  <author ref="http://syriaca.org/person/122">George, bishop of the Arabs</author>
+                  <title ref="" xml:lang="en">Reply to a question laid before George by the
+                      deacon Bar-had-bě-shabbā of the convent of Beth-Mělūtā or
+                    Tělīthā</title>
+                  <rubric xml:lang="syr">ܦܘܢܝ ܦܬܓܡܐ̣. ܠܘܬ ܫܘܐܠܘܢܐ ܡܕܡ ܗܪܛܝܩܝܐ ܕܐܬܩ̇ܪܒ ܠܗ݀. ܡܢ ܢܟܦܐ
+                    ܫܡܫܐ ܒܪܚܕܒܫܒܐ̇. ܕܡܢ ܥܘܡܪܐ ܩܕܝܫܐ ܕܒܝܬ ܡܠܘܛܐ ܐܘ ܟܝܬ ܕܛܠܝ̇ܬܐ</rubric>
+                  <incipit xml:lang="syr"/>
+                  <quote xml:lang="syr">ܐܬܬ̇ܨܚ ܘܐܬ݂ܟܬܒ̣ ܒܐܝܪܚ ܟܢܘܢ ܐܚܪܝ̇. ܕܫܢܬ ܐ܏ܟܘ ܕܝܘ̈ܢܝܐ.<locus
+                      from="" to=""/></quote>
+                  <explicit xml:lang="syr">
+                    <locus to="" from=""/>
+                  </explicit>
+                  <finalRubric xml:lang="syr">
+                    <locus to="" from=""/>
+                  </finalRubric>
+                  <note>It is dated <date>A. Gr. 1026</date>, <date>A.D. 715</date></note>
+                </msItem>
+                <msItem>
+                  <locus to="" from="241b"/>
+                  <author ref="">Yeshūa', of the village of Anab</author>
+                  <author ref="http://syriaca.org/person/122">George, bishop of the Arabs</author>
+                  <title ref="" xml:lang="en">Reply to a heretical question, extracted from a letter
+                    to the priest and recluse <persName>Yeshūa', of the village of
+                    Anab</persName></title>
+                  <rubric xml:lang="syr">ܡܢ ܟܪܛܝܣܐ ܐܚܪܢܐ܀ ܦܘܢܝ ܦܬܓܡܐ̣. ܠܘܬ ܫܘܐܠܐ ܡܕܡ ܐܚܪܢܐ ܗܪܛܝܩܝܐ
+                    ܕܐܬܩ̇ܪܒ ܠܗ݀. ܡܢ ܩܫܝܫܐ ܡܪܝ ܝܫܘܥ ܚܒܝܫܝܐ ܕܒܐܢܒ ܩܪܝܬܐ܀ ܒܬܪ ܣܓܝܐ̈ܬܐ ܕܡܢ
+                    ܫܘܪܝܐ.</rubric>
+                  <incipit xml:lang="syr"/>
+                  <quote xml:lang="syr">
+                    <locus from="" to=""/>
+                  </quote>
+                  <explicit xml:lang="syr">
+                    <locus to="" from=""/>
+                  </explicit>
+                  <finalRubric xml:lang="syr">
+                    <locus to="" from=""/>
+                  </finalRubric>
+                  <note/>
+                </msItem>
+                <msItem>
+                  <locus to="" from="245a"/>
+                  <author ref="">Yeshūa', of the village of Anab</author>
+                  <author ref="http://syriaca.org/person/122">George, bishop of the Arabs</author>
+                  <title ref="" xml:lang="en">Letter to the same Yeshūa'</title>
+                  <rubric xml:lang="syr">ܦܘܢܝ ܦܬܓܡܐ̣ ܠܘܬ ܫܘ̈ܐܠܐ ܬܫܥܐ ܕܫܐܠܗ ܩܫܝܫܐ ܝܫܘܥ
+                    ܚܒܝܫܝܐ</rubric>
+                  <incipit xml:lang="syr"/>
+                  <quote xml:lang="syr">
+                    <locus from="" to=""/>
+                  </quote>
+                  <explicit xml:lang="syr">
+                    <locus to="" from=""/>
+                  </explicit>
+                  <finalRubric xml:lang="syr">
+                    <locus to="" from=""/>
+                  </finalRubric>
+                  <note>dated <date>A. Gr. 1025</date>, <date>A.D. 714</date>.</note>
+                  <note>It has been edited by <bibl>de Lagarde in his Analecta Syriaca, pp. 108
+                      —134</bibl>, and translated in part by <bibl>Cowper in his Syriac
+                      Miscellanies, pp. 61</bibl>, seqq. </note>
+                  <note>It is divided into 9 sections, of which the first three treat of the writer
+                    called "<ref>the Persian Sage</ref>," <quote xml:lang="syr">ܚܟܝܡܐ ܦܪܣܝܐ</quote>,
+                    and of passages in his works; <note>See <bibl>Wright’s edition of the Homilies
+                        of Aphraates, vol. i., pp. 19</bibl>, seqq.</note> the fourth, of the case
+                    of an orthodox priest giving absolution to a heretical deacon; the fifth, of
+                      <persName ref="http://syriaca.org/person/1761">Gregory the
+                      Illuminator</persName>, who converted the Armenians; the sixth, of
+                      <persName>S. Simeon the Aged</persName>, who received our Lord in the Temple ;
+                    the seventh, of persons who offer up prayers or incense, or celebrate the holy
+                    Eucharist, with their heads covered; the eighth, of newly baptized children, who
+                    are possessed of a devil (<quote xml:lang="syr">ܕܡܬ݀ܬܥܒܕܝܢ ܡܢ ܣܛܢܐ</quote>,
+                      <quote xml:lang="grc">ἐνεργούμενοι</quote>); and the ninth, of nocturnal
+                    temptation, <quote xml:lang="syr">ܡܛܠ ܢܣܝܘܢܐ ܗ̇ܘ ܠܠܝܝܐ</quote>. </note>
+                  <note>In the course of this letter the writer cites the ecclesiastical histories
+                    of <persName ref="http://syriaca.org/person/781">Theodoret</persName>
+                      (<locus>sect. 1, fol. 247 b</locus>), <persName
+                      ref="http://syriaca.org/person/849">Socrates</persName> (<locus>sect. 1, fol.
+                      248 a</locus>), and <persName>Eusebius</persName> (<locus>sect. 5, fol. 255
+                      b</locus>); <persName ref="http://syriaca.org/person/3">Bar-daisān</persName>,
+                    <quote xml:lang="syr">ܒܫܪܒܐ ܚܕ ܕܥܒܝܕ ܠܗ ܡܛܠ ܣܘܢ̈ܘܕܘ</quote> (<quote xml:lang="grc">σύνοδοι</quote>) <quote xml:lang="syr">ܕܠܘܬ ܚܕ̈ܕܐ ܕܢܗܝܪ̈ܐ ܕܫܡܝܐ</quote> (<locus>sect.
+                      2, fol. 218 b</locus>); <persName ref="http://syriaca.org/person/537"
+                      >Hippolytus</persName>, <quote xml:lang="syr">ܒܡܐܡܪܐ ܏ܕܕ ܕܥܠ ܕܢܝܐܝܠ ܢܒܝܐ</quote> (<locus>sect. 2, fol. 249
+                      a</locus>); <persName>Jacob of Batnae</persName>, <quote xml:lang="syr">ܒܡܐܡܪܐ ܕܫܬܐ ܕܡܢ ܗܠܝܢ
+                    ܕܥܒܝܕܝܢ ܠܗ ܥܠ ܐܫܬܬ ܝܘ̈ܡܐ</quote> (<locus>sect. 2, fol. 249 b</locus>);
+                      <persName>Athanasius</persName>, <quote xml:lang="syr">ܒܬܫܥܝܬܐ ܗ̇ܝ ܕܟܬ̣ܒ ܥܠ ܐܢܛܘܢܝܘܣ ܗ̇ܘ ܥܢܘܝܐ</quote>
+                      (<locus>sect. 8, fol. 259 b</locus>); and <persName
+                      ref="http://syriaca.org/person/51">Severus of Antioch</persName>, letter to
+                    the monks of the <placeName>convent of Abbā Peter</placeName> (<locus>sect. 7,
+                      fol. 258 b</locus>), and sermon on <ref target="http://syriaca.org/work/9641"
+                      >S. John's Gospel, ch. ix. 1</ref>, seqq. (<locus>sect. 8, fol. 260
+                    a</locus>).</note>
+                </msItem>
+                <msItem>
+                  <locus to="" from="261a"/>
+                  <author ref="">Yeshūa', of the village of Anab</author>
+                  <author ref="http://syriaca.org/person/122">George, bishop of the Arabs</author>
+                  <title ref="" xml:lang="en">Letter to the same Yeshūa', containing replies to 3
+                    questions</title>
+                  <rubric xml:lang="syr">ܐܬܟܬ݂ܒܬ݂ ܏ܒܝ ܒܟ̇ܢܘܢ ܩܕܝܡ ܕܫܢܬ ܐ܏ܟܛ ܕܝܘ̈ܢܝܐ </rubric>
+                  <incipit xml:lang="syr"/>
+                  <quote xml:lang="syr">
+                    <locus from="" to=""/>
+                  </quote>
+                  <explicit xml:lang="syr">
+                    <locus to="" from=""/>
+                  </explicit>
+                  <finalRubric xml:lang="syr">
+                    <locus to="" from=""/>
+                  </finalRubric>
+                  <note>dated <date>A. Gr. 1029</date>, <date>A.D. 718</date></note>
+                </msItem>
+                <msItem>
+                  <locus to="" from="263a"/>
+                  <author ref="">Priest Jacob</author>
+                  <author ref="http://syriaca.org/person/122">George, bishop of the Arabs</author>
+                  <title ref="" xml:lang="en">Letter to the priest Jacob, his syncellus (ܣܘܢܩܠܗ),
+                    explaining a passage in one of the sermons of <persName ref="http://syriaca.org/person/511">Gregory
+                      Nazianzen</persName>
+                  </title>
+                  <rubric xml:lang="syr"/>
+                  <incipit xml:lang="syr"/>
+                  <quote xml:lang="syr">
+                    <locus from="" to=""/>
+                  </quote>
+                  <explicit xml:lang="syr">
+                    <locus to="" from=""/>
+                  </explicit>
+                  <finalRubric xml:lang="syr">
+                    <locus to="" from=""/>
+                  </finalRubric>
+                  <note><bibl>Opera, t. i., p. 18 C</bibl>, <quote xml:lang="grc">Πρῶτον μὲν δὴ τοῦτο, ὦν εἴπομεν,
+                    εὐλαβεῖσθαι ἄξιον, κ.τ.λ.</quote> </note>
+                  <note>At the end there is a brief explanation of a passage in the funeral sermon on
+                    <persName ref="http://syriaca.org/person/1757">Gorgonia</persName>.</note>
+                </msItem>
+                <msItem>
+                  <locus to="" from="264b"/>
+                  <author ref="http://syriaca.org/person/1054">John the Stylite</author>
+                  <author ref="http://syriaca.org/person/122">George, bishop of the Arabs</author>
+                  <title ref="" xml:lang="en">Reply to 8 questions sent to him by John the Stylite,
+                    of the <placeName>convent of Litharb</placeName> (?)</title>
+                  <rubric xml:lang="syr">ܕܚܣܝܐ ܓܐ݊ܘܪܓܝ ܐܦܝܣܩܘܦܐ ܕܥܡ̈ܡܐ ܛܝ̈ܝܐ̣. ܦܘܢܝ ܦܬܓܡܐ̣ ܠܘܬ
+                    ܫ̈ܘܐܠܐ ܏ܚ܇ ܕܐܫܬܕܪܘ ܠܗ ܡܢ ܩܫܝܫܐ ܝܘܚܢܢ ܐܣܛܘܢܝܐ ܕܒܕܝܪܐ ܕܠܝܬܐܪܒ</rubric>
+                  <incipit xml:lang="syr"/>
+                  <quote xml:lang="syr">ܐܬܬܨ̇ܚ ܘܐܬ݂ܟܬܒ ܗܠܝ̣ܢ. ܒܝܪܚ ܬܡܘܙ ܕܫܢܬ ܐ܏ܟܗ..<locus from=""
+                      to=""/></quote>
+                  <explicit xml:lang="syr">
+                    <locus to="" from=""/>
+                  </explicit>
+                  <finalRubric xml:lang="syr">
+                    <locus to="" from=""/>
+                  </finalRubric>
+                  <note>The questions relate to matters of chronology and astronomy.</note>
+                  <note>This letter is dated <date>A. Gr. 1025</date>, <date>A.D. 714</date></note>
+                </msItem>
+                <msItem>
+                  <locus to="" from="272b"/>
+                  <author ref="http://syriaca.org/person/113">Jacob of Edessa</author>
+                  <author ref="http://syriaca.org/person/122">George, bishop of the Arabs</author>
+                  <title ref="" xml:lang="en">Letter to the same, containing answers to 7 questions,
+                    principally regarding difficult passages in the letters of Jacob of
+                    Edessa</title>
+                  <rubric xml:lang="syr">ܡܛܠ ܡ̈ܠܐ ܡܕܡ ܕܐܬܥ̈ܣܩܝܢ ܠܗ܇ ܒܐܓܪ̈ܬܗ ܕܚܣܝܐ ܝܥܩ݊ܘܒ ܐܦܝܣܩܘܦܐ
+                    ܕܐܘܪܗܝ ܡܕܝܢܬܐ</rubric>
+                  <incipit xml:lang="syr"/>
+                  <quote xml:lang="syr">ܐܬܬ̇ܨܚ ܘܐܬ݂ܟܬܒ ܗܠܝ̣ܢ ܒܫܘܪܝܗ ܕܐܕܪ ܕܫܢܬ ܐܠܦܐ ܘ܏܏ܟܘ
+                      ܕܝܘ̈ܢܝܐ.<locus from="" to=""/></quote>
+                  <explicit xml:lang="syr">
+                    <locus to="" from=""/>
+                  </explicit>
+                  <finalRubric xml:lang="syr">
+                    <locus to="" from=""/>
+                  </finalRubric>
+                  <note>It is dated <date>A. Gr. 1026</date>, <date>A.D. 715</date></note>
+                </msItem>
+                <msItem>
+                  <locus to="" from="278a"/>
+                  <author ref="http://syriaca.org/person/113">Jacob of Edessa</author>
+                  <author ref="http://syriaca.org/person/122">George, bishop of the Arabs</author>
+                  <title ref="" xml:lang="en">Letter to the same, replying to 3 questions on matters
+                    of chronology and astronomy</title>
+                  <rubric xml:lang="syr">ܐܬܬܨ̣ܚܬ ܘܐܬ݂ܟܬܒܬ݂̇ ܒܐܝܪܚ ܐܕܪ ܕܫܢܬ ܐ܏ܟܙ</rubric>
+                  <incipit xml:lang="syr"/>
+                  <quote xml:lang="syr">
+                    <locus from="" to=""/>
+                  </quote>
+                  <explicit xml:lang="syr">
+                    <locus to="" from=""/>
+                  </explicit>
+                  <finalRubric xml:lang="syr">
+                    <locus to="" from=""/>
+                  </finalRubric>
+                  <note>dated <date>A. Gr. 1027</date>, <date>A.D. 716</date></note>
+                </msItem>
+                <msItem>
+                  <locus to="" from="284a"/>
+                  <author ref="http://syriaca.org/person/113">Jacob of Edessa</author>
+                  <author ref="http://syriaca.org/person/122">George, bishop of the Arabs</author>
+                  <title ref="" xml:lang="en">Letter to the same, on a dispute that had arisen at an
+                    assembly of monks and clergy, some maintaining that sins arc forgiven through
+                    the prayers of the priests, others, that sins are not forgiven, except through works of repentance</title>
+                  <rubric xml:lang="syr">ܕܡܫܬܒܩܝܢ ܚܛܗ̈ܐ ܒܝܕ ܨܠܘ̈ܬܐ ܕܟܗ̈ܢܐ</rubric>
+                  <rubric xml:lang="syr">ܕܠܐ ܡܫܬܒܩܝܢ ܚ̈ܛܗܐ ܐܠܐ ܐܢ ܒܝܕ ܥܡ̈ܠܐ ܕܬܝܒܘܬܐ.</rubric>
+                  <incipit xml:lang="syr"/>
+                  <quote xml:lang="syr">ܐܬܟ̣ܬܒܬ ܘܐܫܬܠ̣ܡܬ݂ ܒܫܬܐ ܒܐܕܪ ܕܫܢܬ ܐ܏ܟܛ ܕܝܘ̈ܢܝܐ.<locus from=""
+                      to=""/></quote>
+                  <explicit xml:lang="syr">
+                    <locus to="" from=""/>
+                  </explicit>
+                  <finalRubric xml:lang="syr">
+                    <locus to="" from=""/>
+                  </finalRubric>
+                  <note>The works of <persName ref="http://syriaca.org/person/452">Dionysius the Areopagite</persName> are cited several
+                    times. </note>
+                  <note>It is dated <date>A.Gr. 1029</date>, <date>A.D. 718</date></note>
+                </msItem>
+                <msItem>
+                  <locus to="" from="290a"/>
+                  <author ref="http://syriaca.org/person/122">Abraham</author>
+                  <author ref="">George, bishop of the Arabs</author>
+                  <title ref="" xml:lang="en">Letter to one Abraham, on a passage from one of the
+                      <ref>madrāshē of Ephraim on Faith</ref></title>
+                  <rubric xml:lang="syr">ܐܬܬܟܣܘ ܡܪ̈ܚܐ ܘܐܙܕܓܪܘ ܒܨ̈ܘܝܐ. ܘܚܙܘ ܕܠܟܝܢܐ̣ ܠܐ ܐܢܫ ܡܨܐ ܣ̇ܦܩ.
+                    ܏ܘܫ.</rubric>
+                  <incipit xml:lang="syr"/>
+                  <quote xml:lang="syr">
+                    <locus from="" to=""/>
+                  </quote>
+                  <explicit xml:lang="syr">
+                    <locus to="" from=""/>
+                  </explicit>
+                  <finalRubric xml:lang="syr">
+                    <locus to="" from=""/>
+                  </finalRubric>
+                  <note/>
+                </msItem>
+              </msItem>
+              <msItem defective="true">
+                <locus to="" from="291a"/>
+                <author ref="http://syriaca.org/person/1054">John the Stylite</author>
+                <author ref="">Daniel, a priest of the Arab tribe of the ܛܘ̈ܥܝܐ</author>
+                <title ref="" xml:lang="en">Letter of John the Stylite, of the <placeName>convent of
+                    Litharb</placeName> (?), to Daniel, a priest of the Arab tribe of the ܛܘ̈ܥܝܐ, on
+                    <ref target="http://syriaca.org/work/9628">Gen. xlix. 10</ref></title>
+                <rubric xml:lang="syr">ܐܓܪܬܐ ܘܫ̇ܪܝܐ ܕܫܘܐܠܐ ܕܟܬ݂ܒ ܝܘܚܢܢ ܐܣܛܘܢܝܐ ܕܒܕܝܪܐ ܕܠܝܬܐܪܒ̣. ܠܘܬ
+                  ܕܢܝܐܝܠ ܩܫܝܫܐ ܛܘܥܝܐ̣. ܡܛܠ ܗ̇ܝ ܕܐܝܟܢܐ ܘܐܝܟܐ ܘܐܡܬܝ ܫܠ̣ܡܬ ܢܒܝܘܬܗ ܕܝܥܩܘܒ ܪܝܫ ܐܒ̈ܗܬܐ
+                  ܕܐܡܪ̈. ܕܠܐ ܢܥ̣ܢܕ ܪܝܫܐ ܡܢ ܝܗܘܕܐ ܘܕܫܪܟܐ.</rubric>
+                <incipit xml:lang="syr"/>
+                <quote xml:lang="syr">
+                  <locus from="" to=""/>
+                </quote>
+                <explicit xml:lang="syr">
+                  <locus to="" from=""/>
+                </explicit>
+                <finalRubric xml:lang="syr">
+                  <locus to="" from=""/>
+                </finalRubric>
+                <note>The writer cites the historians <persName>Eusebius</persName> and
+                    <persName>Andronicus</persName>, <locus>fol. 291 a</locus>; <persName
+                    ref="http://syriaca.org/person/573">Chrysostom</persName>, <quote xml:lang="syr"
+                    >ܒܡܐܡܪܐ ܕܬܪܝܢ ܕܥܒܝܕ ܠܗ ܠܘܩܒܠ ܝܗ̈ܘܕܝܐ</quote>, <locus>fol. 292</locus>; <persName
+                    ref="http://syriaca.org/person/430">Cyril of Alexandria</persName>, <quote
+                    xml:lang="syr">ܒܡܐܡܪܐ ܚܕ </quote>ܕܥܒܝܕ ܠܗ ܥܠ ܫܒ̈ܘܥܐ ܕܕܢܝܐܝܠ, <locus>fol. 292 a
+                    and b</locus>; <persName ref="http://syriaca.org/person/537"
+                    >Hippolytus</persName> and <persName ref="http://syriaca.org/person/13"
+                    >Ephraim</persName>, commentaries on <ref target="http://syriaca.org/work/9570"
+                    >Daniel</ref>, <locus>fol. 292 b</locus>; <persName>Severus Sabocht (ܣܐܘܪܐ
+                    ܣܒܘܟܬ), bishop of Kinnesrīn</persName>, <quote xml:lang="syr">ܒܡܐܡܪܐ ܗ̇ܘ ܕܥܒܝܕ
+                    ܠܗ ܡܛܠܬܗܘܢ ܕܫܒ̈ܘܥܐ ܕܕܢܝܐܝܠ</quote>, <locus>fol. 293 a</locus>; <persName
+                    ref="http://syriaca.org/person/113">Jacob of Edessa</persName>, one of his
+                  letters, <locus>fol. 293 b</locus>; and <persName
+                    ref="http://syriaca.org/person/122">George, bishop of the Arabs</persName>,
+                    <quote xml:lang="syr">ܚܣܝܐ ܕܝܢ ܡܪܝ ܓܐܘܪܓܝ ܐܒܐ ܕܝܠܢ ܓܘ̇ܢܝܐ ܘܐܦܝܣܩܘܦܐ ܕܝܠܟܘܢ: ܟܬ݂ܒ
+                    ܐܦ ܗ̣ܘ ܒܦܘܢܝ ܦܬܓܡܐ ܕܫܘܐܠܐ ܕܥܣܪܐ ܕܠܘܬ ܝܥܩܘܒ ܩܫܝܫܐ ܣܘܢܩܠܗ: ܏ܘܫ.,</quote>
+                  <locus>fol. 293 b</locus>.</note>
+                <note>The last leaf is much mutilated.</note>
+              </msItem>
+            </msItem>
+          </msContents>
+          <physDesc>
+            <objectDesc form="codex">
+              <supportDesc material="perg">
+                <extent>
+                  <measure unit="content_pending" quantity="-1"/>
+                </extent>
+                <foliation/>
+                <collation/>
+                <condition>
+                  <list>
+                    <item>
+                      <p>Vellum, about 9 7/8 in. by 6 5/8, consisting of 294 leaves, some of which
+                        are much stained and the last is mutilated. The quires, 30 in number, are
+                        signed with letters. There are from 27 to 41 lines in each page. Leaves are
+                        wanting after foll. 8 and 151. This manuscript seems to have been written by
+                        three hands, foll. 1—16 and foll. 28—79 b being in a good, though rather
+                        coarse, Estrangělā; foll. 79 b —294 in a finer Estrangělā; and foll. 17— 27
+                        in a more current hand. It belongs to the end of the viiith or beginning of
+                        the ixth cent. The contents are of a very miscellaneous character.</p>
+                    </item>
+                  </list>
+                </condition>
+              </supportDesc>
+              <layoutDesc>
+                <p>Content pending</p>
+              </layoutDesc>
+            </objectDesc>
+            <handDesc>
+              <handNote scope="" script=""
+                medium="">
+                <desc></desc>
+              </handNote>
+            </handDesc>
+            <additions>
+              <p>Remains of several notes, all more or less erased. </p>
+              <list>
+                <item>
+                  <locus from="1a" to=""/>
+                  <p>In one we can read part of an anathema</p>
+                  <p><quote xml:lang="syr"></quote></p>
+                </item>
+                <item>
+                  <locus from="" to=""/>
+                  <p><persName>Abbā Kāmā</persName> (?) presented this book………to the monk
+                    <persName ref="http://syriaca.org/person/1321">John of Edessa</persName>. The words <quote xml:lang="syr">ܐܒܐ ܟܐܡܐ</quote> seem, however, to be a later alteration.</p>
+                  <p>
+                    <quote xml:lang="syr">ܫܲܟܢ ܟܬܒܐ ܗܢܐ . . . ܐܒܐ ܟܐܡܐ ܠܝܘܚܢܢ ܐܘܪܗܝܐ ܕܝܪܝܐ.</quote>
+                  </p>
+                </item>
+              </list>
+            </additions>
+            <bindingDesc>
+              <p>Content pending</p>
+            </bindingDesc>
+            <sealDesc>
+              <p>Content pending</p>
+            </sealDesc>
+            <accMat/>
+          </physDesc>
+          <history>
+            <origin>
+              <origDate notBefore="0775" notAfter="0825" from="" to="" when="">the end of the viiith
+                or beginning of the ixth cent.</origDate>
+              <origPlace ref="" xml:lang=""></origPlace>
+            </origin>
+            <provenance/>
+            <acquisition/>
+          </history>
+          <additional/>
+        </msDesc>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <p>Content pending</p>
+    </encodingDesc>
+    <profileDesc/>
+    <revisionDesc status="draft">
+      <change when="" who="http://syriaca.org/documentation/editors.xml#cchen">Initial TEI encoding.</change>
+      <change type="planned" subtype="arabic">Add missing Arabic text. p 986 Wright II, the footnote
+        of section 34</change>
+      <change type="planned" subtype="question">Question in Word Doc to be Addressed: 1a contains an
+        anathema p 989 Wright II</change>
+    </revisionDesc>
+  </teiHeader>
+  <facsimile>
+    <formula>Content pending</formula>
+  </facsimile>
+  <text>
+    <body>
+      <bibl>Content pending</bibl>
+    </body>
+  </text>
+</TEI>


### PR DESCRIPTION
29A ends on Wright II 981, Part f of Section 7 "Extracts from the writings of Philoxenus"

29B ends on Wright II 982, Part h of Section 11 "Miscellaneous extracts"

29C ends on Wright II 986, Section 34 "Demonstrations from the Old Testament"

Overall manuscript information is contained in 29A and may not be found in the other parts